### PR TITLE
fix uv tool upgrade command

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ pipx install itzi
 ### Updating
 ```bash
 # Update to latest version
-uv tool update itzi
+uv tool upgrade itzi
 ```
 
 ## 🎯 Quick Start

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -27,7 +27,7 @@ This will automatically download Itzï and install it in its own python environm
 
 When it is time to update Itzï to its last version, you can use:
 
-    uv tool update itzi
+    uv tool upgrade itzi
 
 Installation on Windows
 -------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 
 [project.urls]
-Homepage = "http://www.itzi.org"
+Homepage = "https://www.itzi.org"
 Documentation = "https://itzi.readthedocs.io"
 Repository = "https://github.com/ItziModel/itzi"
 Issues = "https://github.com/ItziModel/itzi/issues/"


### PR DESCRIPTION
The readme and docs wrongly refer to `uv too update` when the actual command is `uv tool upgrade`