### PR TITLE
convert icechunk integration test to use sqlite

### DIFF
--- a/src/itzi/data_containers.py
+++ b/src/itzi/data_containers.py
@@ -44,10 +44,12 @@ class DrainageAttributes:
     """A base class for drainage data attributes."""
 
     @classmethod
-    def get_columns_definition(cls) -> list[tuple[str, str]]:
+    def get_columns_definition(cls, cat_primary_key=True) -> list[tuple[str, str]]:
         """Return a list of tuples to create DB columns"""
         type_mapping = {str: "TEXT", int: "INT", float: "REAL"}
         db_columns_def = [("cat", "INTEGER PRIMARY KEY")]
+        if not cat_primary_key:
+            db_columns_def = [("cat", "INTEGER")]
         for f in dataclasses.fields(cls):
             db_field = (f.name, type_mapping[f.type])
             db_columns_def.append(db_field)

--- a/src/itzi/providers/icechunk_output.py
+++ b/src/itzi/providers/icechunk_output.py
@@ -243,7 +243,7 @@ class IcechunkRasterOutputProvider(RasterOutputProvider):
     def get_dataset_from_dict(self, array_dict, sim_time=None):
         """From a dict of arrays, return an xarray dataset."""
         data_vars = {}
-        if sim_time:
+        if sim_time is not None:
             if isinstance(sim_time, datetime):
                 time_dtype = "datetime64[ms]"
                 sim_time_np = np.datetime64(sim_time, "ms")
@@ -283,7 +283,7 @@ class IcechunkRasterOutputProvider(RasterOutputProvider):
                 "standard_name": self.cf_names[key],
                 "long_name": self.descriptions[key],
             }
-            if sim_time:
+            if sim_time is not None:
                 arr = np.expand_dims(arr, axis=0)
 
             data_array = xr.DataArray(
@@ -292,7 +292,7 @@ class IcechunkRasterOutputProvider(RasterOutputProvider):
                 name=var_name,  # Write the requested name
                 attrs=var_attributes,
             )
-            if sim_time:
+            if sim_time is not None:
                 assert data_array["time"].dtype == time_dtype
                 data_array.encoding["time"] = time_encoding
             data_vars[var_name] = data_array
@@ -303,7 +303,7 @@ class IcechunkRasterOutputProvider(RasterOutputProvider):
         dataset = xr.Dataset(data_vars, attrs=dataset_attributes)
 
         # Set encoding on the time coordinate of the dataset itself
-        if sim_time:
+        if sim_time is not None:
             dataset["time"].encoding.update(time_encoding)
 
         return dataset

--- a/src/itzi/simulation_factories.py
+++ b/src/itzi/simulation_factories.py
@@ -13,10 +13,8 @@ GNU General Public License for more details.
 """
 
 from typing import Dict, TYPE_CHECKING
-from pathlib import Path
 
 import numpy as np
-from numpy.typing import ArrayLike, DTypeLike
 
 import itzi.rasterdomain as rasterdomain
 import itzi.messenger as msgr
@@ -26,7 +24,6 @@ from itzi.simulation_builder import SimulationBuilder
 if TYPE_CHECKING:
     from itzi.providers.grass_interface import GrassInterface
     from itzi.data_containers import SimulationConfig
-    import icechunk
 
 
 def create_grass_simulation(
@@ -67,76 +64,6 @@ def create_grass_simulation(
     )
     return (
         SimulationBuilder(sim_config, grass_interface.get_npmask(), dtype)
-        .with_input_provider(raster_input_provider)
-        .with_raster_output_provider(raster_output_provider)
-        .with_vector_output_provider(vector_output_provider)
-        .build()
-    )
-
-
-def create_icechunk_simulation(
-    sim_config: "SimulationConfig",
-    arr_mask: ArrayLike,
-    input_icechunk_storage: "icechunk.Storage",
-    output_icechunk_storage: "icechunk.Storage",
-    input_icechunk_group: str = "main",
-    output_dir: Path = Path("."),
-    dtype: DTypeLike = np.float32,
-) -> tuple[Simulation, Dict[str, rasterdomain.TimedArray]]:
-    """A factory function that returns a Simulation object with Icechunk raster backend and Parquet vector backend."""
-    msgr.verbose("Setting up models...")
-    try:
-        import pyproj
-        from itzi.providers.icechunk_input import (
-            IcechunkRasterInputProvider,
-            IcechunkRasterInputConfig,
-        )
-        from itzi.providers.icechunk_output import IcechunkRasterOutputProvider
-        from itzi.providers.geoparquet_output import ParquetVectorOutputProvider
-    except ImportError:
-        raise ImportError(
-            "To use the Icechunk backend, install itzi with: "
-            "'uv tool install itzi[cloud]' "
-            "or 'pip install itzi[cloud]'"
-        )
-
-    # Set up raster input provider
-    raster_input_provider_config: IcechunkRasterInputConfig = {
-        "icechunk_storage": input_icechunk_storage,
-        "icechunk_group": input_icechunk_group,
-        "input_map_names": sim_config.input_map_names,
-        "simulation_start_time": sim_config.start_time,
-        "simulation_end_time": sim_config.end_time,
-    }
-    raster_input_provider = IcechunkRasterInputProvider(config=raster_input_provider_config)
-    domain_data = raster_input_provider.get_domain_data()
-
-    # Set up raster output provider
-    # Generate coordinate arrays from domain_data
-    coords = domain_data.get_coordinates()
-    x_coords = coords["x"]
-    y_coords = coords["y"]
-    crs = pyproj.CRS.from_wkt(domain_data.crs_wkt)
-    raster_output_provider = IcechunkRasterOutputProvider(
-        {
-            "out_map_names": sim_config.output_map_names,
-            "crs": crs,
-            "x_coords": x_coords,
-            "y_coords": y_coords,
-            "icechunk_storage": output_icechunk_storage,
-        }
-    )
-
-    # Set up vector output provider
-    vector_output_provider = ParquetVectorOutputProvider(
-        {
-            "crs": crs,
-            "output_dir": output_dir,
-            "drainage_map_name": sim_config.drainage_output,
-        }
-    )
-    return (
-        SimulationBuilder(sim_config, arr_mask, dtype)
         .with_input_provider(raster_input_provider)
         .with_raster_output_provider(raster_output_provider)
         .with_vector_output_provider(vector_output_provider)


### PR DESCRIPTION
This converts the ea8b test to using sqlite instead of parquet, and relative time instead of absolute. In the process, some bugs where uncovered and fixed.