### PR TITLE
fix SimulationBuilder output type hint

### DIFF
--- a/src/itzi/simulation_builder.py
+++ b/src/itzi/simulation_builder.py
@@ -78,7 +78,7 @@ class SimulationBuilder:
         self.vector_output_provider = provider
         return self
 
-    def build(self) -> tuple[Simulation, Optional[Dict[str, rasterdomain.TimedArray]]]:
+    def build(self) -> Simulation:
         """Build and return the simulation with optional timed arrays."""
         # Validate required components
         if self.domain_data is None:


### PR DESCRIPTION
SimulationBuilder returns only a Simulation object. TimedArray are now included in the Simulation.