### PR TITLE
icechunk output: use seconds instead of ms in timedelta

### DIFF
--- a/src/itzi/providers/icechunk_output.py
+++ b/src/itzi/providers/icechunk_output.py
@@ -121,7 +121,7 @@ class IcechunkRasterOutputProvider(RasterOutputProvider):
                     return latest_time.values.astype("datetime64[ms]").astype(datetime)
                 elif np.issubdtype(latest_time.dtype, np.timedelta64):
                     return timedelta(
-                        milliseconds=int(latest_time.values.astype("timedelta64[ms]").astype(int))
+                        seconds=int(latest_time.values.astype("timedelta64[s]").astype(int))
                     )
                 else:
                     return None
@@ -248,9 +248,9 @@ class IcechunkRasterOutputProvider(RasterOutputProvider):
                 sim_time_np = np.datetime64(sim_time, "ms")
                 time_unit = "milliseconds since 1970-01-01T00:00:00"
             elif isinstance(sim_time, timedelta):
-                time_dtype = "timedelta64[ms]"
-                sim_time_np = np.timedelta64(sim_time, "ms")
-                time_unit = "milliseconds"
+                time_dtype = "timedelta64[s]"
+                sim_time_np = np.timedelta64(sim_time, "s")
+                time_unit = "seconds"
             else:
                 raise ValueError(f"Unknown temporal type: {type(sim_time)}")
 


### PR DESCRIPTION
Using seconds instead of ms increases the compatibility with the GRASS temporal framework, where seconds is the smallest unit supported.