### PR TITLE
Force time-stepping at input maps update

### DIFF
--- a/src/itzi/massbalance.py
+++ b/src/itzi/massbalance.py
@@ -53,7 +53,9 @@ class MassBalanceLogger:
             elif "percent_error" == key:
                 line_to_write[key] = f"{value:.2%}"
             elif isinstance(value, numbers.Real) and not isinstance(value, int):
-                line_to_write[key] = f"{value:.3f}"
+                # Keep enough precision in the CSV for downstream coherence checks,
+                # especially when large boundary and inflow volumes nearly cancel.
+                line_to_write[key] = f"{value:.6f}"
             else:
                 line_to_write[key] = value
 

--- a/src/itzi/providers/base.py
+++ b/src/itzi/providers/base.py
@@ -47,9 +47,11 @@ class RasterInputProvider(ABC):
         self, map_key: str, current_time: datetime
     ) -> tuple[np.ndarray, datetime, datetime]:
         """Take a given map key and current time
-        return a numpy array associated with its half-open validity window `[start, end)`
-        if no map is found, return None instead of an array
-        and a default start_time and end_time."""
+        return a numpy array associated with its half-open validity window `[start, end)`.
+
+        If no array is active at `current_time`, return `None` plus the half-open interval
+        for which that "no data" result remains valid.
+        """
         pass
 
 

--- a/src/itzi/providers/base.py
+++ b/src/itzi/providers/base.py
@@ -47,7 +47,7 @@ class RasterInputProvider(ABC):
         self, map_key: str, current_time: datetime
     ) -> tuple[np.ndarray, datetime, datetime]:
         """Take a given map key and current time
-        return a numpy array associated with its start and end time
+        return a numpy array associated with its half-open validity window `[start, end)`
         if no map is found, return None instead of an array
         and a default start_time and end_time."""
         pass

--- a/src/itzi/providers/grass_input.py
+++ b/src/itzi/providers/grass_input.py
@@ -109,10 +109,15 @@ class GrassRasterInputProvider(RasterInputProvider):
         if self.map_lists[map_key] is None:
             return None, self.start_time, self.end_time
         else:
+            gap_start: datetime = self.start_time
             for map_name in self.map_lists[map_key]:
-                if map_name.start_time <= current_time <= map_name.end_time:
+                map_start: datetime = max(self.start_time, map_name.start_time)
+                map_end: datetime = min(self.end_time, map_name.end_time)
+                if current_time < map_start:
+                    return None, gap_start, min(self.end_time, map_start)
+                if map_start <= current_time < map_end:
                     arr = self.grass_interface.read_raster_map(map_name.id)
-                    return arr, map_name.start_time, map_name.end_time
+                    return arr, map_start, map_end
+                gap_start: datetime = max(gap_start, map_end)
             else:
-                # This should not happen unless the maps is removed from the GRASS DB after listing the maps.
-                assert None, "No map found for {k} at time {t}".format(k=map_key, t=current_time)
+                return None, min(gap_start, self.end_time), self.end_time

--- a/src/itzi/providers/grass_input.py
+++ b/src/itzi/providers/grass_input.py
@@ -100,24 +100,25 @@ class GrassRasterInputProvider(RasterInputProvider):
     def get_array(
         self, map_key: str, current_time: datetime
     ) -> tuple[np.ndarray | None, datetime, datetime]:
-        """Take a given map key and current time
-        return a numpy array associated with its start and end time
-        if no map is found, return None instead of an array
-        and a default start_time and end_time."""
+        """Return the array and its half-open validity window for a given time.
+        The input series is expected to cover the simulation timeline continuously.
+        Reaching the final `else` therefore means the map set was
+        modified after validation or the provider logic became inconsistent.
+        """
         if map_key not in self.map_lists.keys():
             raise ValueError(f"Unknown map key: {map_key}")
         if self.map_lists[map_key] is None:
             return None, self.start_time, self.end_time
         else:
-            gap_start: datetime = self.start_time
             for map_name in self.map_lists[map_key]:
                 map_start: datetime = max(self.start_time, map_name.start_time)
                 map_end: datetime = min(self.end_time, map_name.end_time)
-                if current_time < map_start:
-                    return None, gap_start, min(self.end_time, map_start)
                 if map_start <= current_time < map_end:
                     arr = self.grass_interface.read_raster_map(map_name.id)
                     return arr, map_start, map_end
-                gap_start: datetime = max(gap_start, map_end)
             else:
-                return None, min(gap_start, self.end_time), self.end_time
+                # No gap is expected here: GRASS temporal sanity is checked before the
+                # simulation starts, so an in-range lookup should always hit one map.
+                raise ValueError(
+                    "No map found for {k} at time {t}".format(k=map_key, t=current_time)
+                )

--- a/src/itzi/providers/memory_input.py
+++ b/src/itzi/providers/memory_input.py
@@ -106,14 +106,14 @@ class MemoryRasterInputProvider(RasterInputProvider):
         for timed_slice in slices:
             if timed_slice.start_time > timed_slice.end_time:
                 raise ValueError(
-                    f"timed slice for '{map_key}' has start_time after end_time: "
+                    f"timed slice for '{map_key}' must have start_time before end_time: "
                     f"{timed_slice.start_time} > {timed_slice.end_time}"
                 )
 
             if previous_slice is not None and timed_slice.start_time < previous_slice.start_time:
                 raise ValueError(f"timed slices for '{map_key}' must be sorted by start_time")
 
-            if previous_slice is not None and timed_slice.start_time <= previous_slice.end_time:
+            if previous_slice is not None and timed_slice.start_time < previous_slice.end_time:
                 raise ValueError(f"timed slices for '{map_key}' must not overlap")
 
             normalized_slice = TimedRasterSlice(
@@ -138,8 +138,21 @@ class MemoryRasterInputProvider(RasterInputProvider):
         if static_array is not None:
             return static_array.copy(), self.start_time, self.end_time
 
-        for timed_slice in self.timed_arrays.get(map_key, ()):
-            if timed_slice.start_time <= current_time <= timed_slice.end_time:
-                return timed_slice.array.copy(), timed_slice.start_time, timed_slice.end_time
+        timed_slices = self.timed_arrays.get(map_key, ())
+        if not timed_slices:
+            return None, self.start_time, self.end_time
 
-        return None, self.start_time, self.end_time
+        gap_start = self.start_time
+        for timed_slice in timed_slices:
+            slice_start = max(self.start_time, timed_slice.start_time)
+            slice_end = min(self.end_time, timed_slice.end_time)
+
+            if current_time < slice_start:
+                return None, gap_start, min(self.end_time, slice_start)
+
+            if slice_start <= current_time < slice_end:
+                return timed_slice.array.copy(), slice_start, slice_end
+
+            gap_start = max(gap_start, slice_end)
+
+        return None, min(gap_start, self.end_time), self.end_time

--- a/src/itzi/providers/memory_input.py
+++ b/src/itzi/providers/memory_input.py
@@ -104,10 +104,12 @@ class MemoryRasterInputProvider(RasterInputProvider):
         previous_slice: TimedRasterSlice | None = None
 
         for timed_slice in slices:
-            if timed_slice.start_time > timed_slice.end_time:
+            # Memory-backed timed slices use half-open intervals [start, end), so
+            # zero-length slices are invalid and touching slices are allowed.
+            if timed_slice.start_time >= timed_slice.end_time:
                 raise ValueError(
                     f"timed slice for '{map_key}' must have start_time before end_time: "
-                    f"{timed_slice.start_time} > {timed_slice.end_time}"
+                    f"{timed_slice.start_time} >= {timed_slice.end_time}"
                 )
 
             if previous_slice is not None and timed_slice.start_time < previous_slice.start_time:
@@ -133,7 +135,13 @@ class MemoryRasterInputProvider(RasterInputProvider):
     def get_array(
         self, map_key: str, current_time: datetime
     ) -> tuple[np.ndarray | None, datetime, datetime]:
-        """Return the array and its validity interval for a given key and time."""
+        """Return the array and its half-open validity interval for a given key and time.
+
+        The memory backend deliberately allows sparse timed inputs.
+        When `current_time` falls in a hole between slices, return `None` and the
+        uncovered half-open interval `[gap_start, next_slice_start)` so the TimedArray
+        cache knows until when the default array remains valid.
+        """
         static_array: np.ndarray | None = self.static_arrays.get(map_key)
         if static_array is not None:
             return static_array.copy(), self.start_time, self.end_time
@@ -147,6 +155,7 @@ class MemoryRasterInputProvider(RasterInputProvider):
             slice_start = max(self.start_time, timed_slice.start_time)
             slice_end = min(self.end_time, timed_slice.end_time)
 
+            # Gap found
             if current_time < slice_start:
                 return None, gap_start, min(self.end_time, slice_start)
 
@@ -155,4 +164,5 @@ class MemoryRasterInputProvider(RasterInputProvider):
 
             gap_start = max(gap_start, slice_end)
 
+        # No map found
         return None, min(gap_start, self.end_time), self.end_time

--- a/src/itzi/providers/xarray_input.py
+++ b/src/itzi/providers/xarray_input.py
@@ -320,7 +320,11 @@ class XarrayRasterInputProvider(RasterInputProvider):
 
     @staticmethod
     def get_active_window(coord_array, target_value):
-        """Return the active slice index and half-open validity window for a time value."""
+        """Return the active slice index and half-open validity window for a time value.
+
+        Exact-boundary lookups belong to the new slice, not the previous one, hence the
+        use of `side="right"`.
+        """
         active_idx = int(np.searchsorted(coord_array, target_value, side="right") - 1)
         if active_idx < 0:
             return None

--- a/src/itzi/providers/xarray_input.py
+++ b/src/itzi/providers/xarray_input.py
@@ -319,25 +319,23 @@ class XarrayRasterInputProvider(RasterInputProvider):
             return bool(np.all(np.diff(arr) <= 0))
 
     @staticmethod
-    def get_bracket_values(coord_array, target_value):
-        """
-        Get the lower and upper bound values that bracket a target value.
+    def get_active_window(coord_array, target_value):
+        """Return the active slice index and half-open validity window for a time value."""
+        active_idx = int(np.searchsorted(coord_array, target_value, side="right") - 1)
+        if active_idx < 0:
+            return None
 
-        Returns:
-            tuple: (lower_value, upper_value)
-        """
-        insert_idx = np.searchsorted(coord_array, target_value)
+        start_value = coord_array[active_idx]
+        if active_idx + 1 < len(coord_array):
+            end_value = coord_array[active_idx + 1]
+        else:
+            end_value = None
+        return active_idx, start_value, end_value
 
-        lower_idx = max(0, insert_idx - 1)
-        upper_idx = min(len(coord_array) - 1, insert_idx)
-
-        # Handle edge cases
-        if insert_idx == 0:
-            upper_idx = 0
-        elif insert_idx >= len(coord_array):
-            lower_idx = len(coord_array) - 1
-
-        return (coord_array[lower_idx], coord_array[upper_idx])
+    def _to_datetime(self, time_value, time_dim: str) -> datetime:
+        if self.temporal_types[time_dim] == TemporalType.RELATIVE:
+            return self.sim_start_time + pd.to_timedelta(time_value).to_pytimedelta()
+        return pd.to_datetime(time_value).to_pydatetime()
 
     def get_array(
         self, map_key: str, current_time: datetime
@@ -356,21 +354,27 @@ class XarrayRasterInputProvider(RasterInputProvider):
         time_dim: str = self.dataset_dims[var_name]["time"]
 
         if time_dim in da.dims:
+            if not self.sim_start_time <= current_time < self.sim_end_time:
+                return None, self.sim_start_time, self.sim_end_time
+
             da_time: xr.DataArray = da[time_dim]
             if self.temporal_types[time_dim] == TemporalType.RELATIVE:
                 # convert datetime to timedelta for the search
                 np_time = np.timedelta64(current_time - self.sim_start_time)
-                da_selected: xr.DataArray = da.sel({time_dim: np_time}, method="ffill")
-                start_np, end_np = self.get_bracket_values(da_time.values, np_time)
-                # convert back to datetime
-                start_time = self.sim_start_time + pd.to_timedelta(start_np).to_pytimedelta()
-                end_time = self.sim_start_time + pd.to_timedelta(end_np).to_pytimedelta()
             else:  # absolute time
                 np_time = np.datetime64(current_time)
-                da_selected: xr.DataArray = da.sel({time_dim: np_time}, method="ffill")
-                start_np, end_np = self.get_bracket_values(da_time.values, np_time)
-                start_time = pd.to_datetime(start_np).to_pydatetime()
-                end_time = pd.to_datetime(end_np).to_pydatetime()
+
+            active_window = self.get_active_window(da_time.values, np_time)
+            if active_window is None:
+                first_time = min(self.sim_end_time, self._to_datetime(da_time.values[0], time_dim))
+                return None, self.sim_start_time, first_time
+
+            active_idx, start_np, end_np = active_window
+            da_selected: xr.DataArray = da.isel({time_dim: active_idx})
+            start_time = max(self.sim_start_time, self._to_datetime(start_np, time_dim))
+            end_time = self.sim_end_time
+            if end_np is not None:
+                end_time = min(self.sim_end_time, self._to_datetime(end_np, time_dim))
         else:
             # If no time dimension, send back the whole array
             start_time: datetime = self.sim_start_time

--- a/src/itzi/rasterdomain.py
+++ b/src/itzi/rasterdomain.py
@@ -68,7 +68,7 @@ class TimedArray:
         return True
         If not return False
         """
-        return bool(self.arr_start <= sim_time <= self.arr_end)
+        return bool(self.arr_start <= sim_time < self.arr_end)
 
     def update_values(self, sim_time: datetime) -> Self:
         """Update array, start_time and end_time from provider
@@ -82,7 +82,7 @@ class TimedArray:
         # check retrieved values
         assert isinstance(arr_start, datetime), "not a datetime object!"
         assert isinstance(arr_end, datetime), "not a datetime object!"
-        assert arr_start <= sim_time <= arr_end, "wrong time retrieved!"
+        assert arr_start <= sim_time < arr_end, "wrong time retrieved!"
         # update object values
         self.arr_start = arr_start
         self.arr_end = arr_end

--- a/src/itzi/rasterdomain.py
+++ b/src/itzi/rasterdomain.py
@@ -64,7 +64,7 @@ class TimedArray:
 
     def is_valid(self, sim_time: datetime) -> bool:
         """input being a time in datetime
-        If the current stored array is within the range of the map,
+        If the current stored array is within the half-open range [start, end),
         return True
         If not return False
         """

--- a/src/itzi/report.py
+++ b/src/itzi/report.py
@@ -12,11 +12,14 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 """
 
+from __future__ import annotations
+
 import copy
 from datetime import datetime, timedelta
 from typing import Dict, TYPE_CHECKING
 
 from itzi import rastermetrics
+from itzi.const import TemporalType
 from itzi.data_containers import SimulationData, MassBalanceData
 from itzi.array_definitions import ARRAY_DEFINITIONS, ArrayCategory
 
@@ -31,10 +34,10 @@ class Report:
     def __init__(
         self,
         start_time: datetime,
-        temporal_type: str,
-        raster_output_provider: "RasterOutputProvider",
-        vector_output_provider: "VectorOutputProvider",
-        mass_balance_logger: "MassBalanceLogger",
+        temporal_type: TemporalType,
+        raster_output_provider: RasterOutputProvider,
+        vector_output_provider: VectorOutputProvider,
+        mass_balance_logger: MassBalanceLogger,
         out_map_names: Dict,
         dt,
     ):
@@ -56,7 +59,7 @@ class Report:
     def step(self, simulation_data: SimulationData):
         """write results at given time-step"""
         sim_time = simulation_data.sim_time
-        if "relative" == self.temporal_type:
+        if self.temporal_type == TemporalType.RELATIVE:
             converted_sim_time = sim_time - self.start_time
         else:
             converted_sim_time = sim_time
@@ -73,13 +76,7 @@ class Report:
         return self
 
     def end(self, final_data: SimulationData):
-        """
-        register maps in gis
-        write max level maps
-        """
-        # do the last step
-        self.step(final_data)
-        # Write last maps
+        """Finalize output providers after the last report has been written."""
         self.raster_provider.finalize(final_data)
         self.vector_provider.finalize(final_data.drainage_network_data)
         return self

--- a/src/itzi/simulation.py
+++ b/src/itzi/simulation.py
@@ -88,7 +88,7 @@ class Simulation:
         # dict of next time-step (datetime object)
         self.next_ts: dict[str, datetime] = {"end": self.end_time}
         self.next_ts["input"] = self.end_time
-        for k in ["hydrology", "surface_flow", "drainage"]:
+        for k in ["hydrology", "drainage"]:
             self.next_ts[k] = self.start_time
         # Schedule the first record step to avoid duplication with initialize()
         self.next_ts["record"] = self.start_time + self.report.dt
@@ -124,6 +124,19 @@ class Simulation:
             cell_surface_area=self.raster_domain.cell_area,
             padded=True,
         )
+
+        # Calculate hmax and vmax of the initial state
+        np.maximum(
+            self.raster_domain.get_array("hmax"),
+            self.raster_domain.get_array("water_depth"),
+            out=self.raster_domain.get_array("hmax"),
+        )
+        np.maximum(
+            self.raster_domain.get_array("vmax"),
+            self.raster_domain.get_array("v"),
+            out=self.raster_domain.get_array("vmax"),
+        )
+
         for arr_key in self.accum_mapping.keys():
             self._update_accum_array(arr_key, self.sim_time)
         # Package data into SimulationData object
@@ -139,6 +152,7 @@ class Simulation:
             drainage_network_data = self.drainage_model.get_drainage_network_data()
         else:
             drainage_network_data = None
+
         simulation_data = SimulationData(
             sim_time=self.sim_time,
             time_step=self.dt.total_seconds(),
@@ -160,32 +174,25 @@ class Simulation:
         return self
 
     def update(self) -> Self:
-        # hydrology #
-        if self.sim_time == self.next_ts["hydrology"]:
+        """Advance one physical interval and report it at the interval end."""
+        step_start: datetime = self.sim_time
+
+        if step_start == self.next_ts["hydrology"]:
             self.hydrology_model.solve_dt()
-            # calculate when will happen the next time-step
             self.next_ts["hydrology"] += self.hydrology_model.dt
             self.hydrology_model.step()
-
-        # drainage #
-        # Equality check works because datetime internally uses int
-        if self.sim_time == self.next_ts["drainage"] and self.drainage_model:
+        if step_start == self.next_ts["drainage"] and self.drainage_model:
             self.drainage_model.step()
-            # Update drainage nodes
-            surface_states = {}
-            cell_area = self.raster_domain.cell_area
-            arr_z = self.raster_domain.get_array("dem")
-            arr_h = self.raster_domain.get_array("water_depth")
-            for node_id, (row, col) in self.node_id_to_loc.items():
-                surface_states[node_id] = {"z": arr_z[row, col], "h": arr_h[row, col]}
-            coupling_flows = self.drainage_model.apply_coupling_to_nodes(surface_states, cell_area)
-            # update drainage array with flux in m/s
-            arr_qd = self.raster_domain.get_array("n_drain")
-            for node_id, coupling_flow in coupling_flows.items():
-                row, col = self.node_id_to_loc[node_id]
-                arr_qd[row, col] = coupling_flow / cell_area
-            # calculate when will happen the next time-step
+            self._apply_drainage_coupling()
             self.next_ts["drainage"] += self.drainage_model.dt
+
+        # Choose the current interval width from the state at step_start
+        try:
+            self.surface_flow.solve_dt()
+        except DtError as e:
+            msgr.fatal(f"{step_start}: Time-step computation error detected in simulation: {e}")
+        self.find_dt(step_start + self.surface_flow.dt)
+        step_end: datetime = step_start + self.dt
 
         # surface flow #
         # update arrays of infiltration, rainfall etc.
@@ -194,92 +201,65 @@ class Simulation:
         try:
             self.surface_flow.dt = self.dt
         except DtError as e:
-            msgr.fatal(f"{self.sim_time}: Time-step errors detected in simulation: {e}")
+            msgr.fatal(f"{step_start}: Time-step errors detected in simulation: {e}")
         # surface_flow.step() raise NullError in case of NaN/NULL cell
-        # if this happen, stop simulation and
-        # output a map showing the errors
+        # if this happen, stop simulation
         try:
             self.surface_flow.step()
         except NullError:
-            msgr.fatal("{}: Null value detected in simulation, terminating".format(self.sim_time))
-        # calculate when should happen the next surface time-step
-        try:
-            self.surface_flow.solve_dt()
-        except DtError as e:
-            msgr.fatal(f"{self.sim_time}: Time-step computation error detected in simulation: {e}")
-        self.next_ts["surface_flow"] += self.surface_flow.dt
+            msgr.fatal("{}: Null value detected in simulation, terminating".format(step_start))
+
+        # Align timed inputs to the interval end before closing and reporting it
+        # under that time label. Due submodels will consume that label on the next update cycle.
+        self.update_input_arrays(step_end)
 
         # Update accumulation arrays
         for arr_key in self.accum_mapping.keys():
-            self._update_accum_array(arr_key, self.sim_time)
+            self._update_accum_array(arr_key, step_end)
 
         # Compute continuity error every x time steps
-        is_first_ts = self.sim_time == self.start_time
-        is_record_due = self.sim_time == self.next_ts["record"]
-        is_ts_over_threshold = self.time_steps_counters["since_last_report"] % 200 == 0
-        is_error_comp_due = is_first_ts or is_ts_over_threshold or is_record_due
+        steps_since_start = self.time_steps_counters["since_start"] + 1
+        steps_since_report = self.time_steps_counters["since_last_report"] + 1
+        is_first_ts = step_start == self.start_time
+        is_final_ts = step_end == self.end_time
+        is_record_due = step_end == self.next_ts["record"]
+        should_write_report = is_record_due or is_final_ts
+        is_ts_over_threshold = steps_since_report % 200 == 0
+        is_error_comp_due = is_first_ts or is_ts_over_threshold or should_write_report
         if is_error_comp_due:
             self.continuity_data = self.get_continuity_data()
 
         # Reporting last to get simulated values #
-        if is_record_due:
-            msgr.verbose(f"{self.sim_time}: Writing output maps...")
-
-            # Package data into SimulationData object
-            raw_arrays = {
-                k: self.raster_domain.get_unmasked(k)
-                for k in self.raster_domain.k_all
-                if k not in self.raster_domain.k_accum
-            }
-            accumulation_arrays = {
-                k: self.raster_domain.get_unmasked(k) for k in self.raster_domain.k_accum
-            }
-            if self.drainage_model:
-                drainage_network_data = self.drainage_model.get_drainage_network_data()
-            else:
-                drainage_network_data = None
-            simulation_data = SimulationData(
-                sim_time=self.sim_time,
-                time_step=self.dt.total_seconds(),
-                time_steps_counter=self.time_steps_counters["since_last_report"],
-                continuity_data=self.continuity_data,
-                raw_arrays=raw_arrays,
-                accumulation_arrays=accumulation_arrays,
-                cell_dx=self.raster_domain.dx,
-                cell_dy=self.raster_domain.dy,
-                drainage_network_data=drainage_network_data,
+        if should_write_report:
+            msgr.verbose(f"{step_end}: Writing output maps...")
+            self.report.step(
+                self._build_simulation_data(
+                    sim_time=step_end,
+                    time_steps_counter=steps_since_report,
+                )
             )
 
-            # Pass data to the reporting module
-            self.report.step(simulation_data)
-
-            # Reset accumulation arrays
             self.old_domain_volume = copy.deepcopy(self.continuity_data.new_domain_vol)
-            self.time_steps_counters["since_last_report"] = 0
             self.raster_domain.reset_accumulations()
             for key in self.accum_update_time:
-                self.accum_update_time[key] = self.sim_time
-            # Update next time step
-            self.next_ts["record"] += self.report.dt
+                self.accum_update_time[key] = step_end
+            if is_record_due:
+                self.next_ts["record"] += self.report.dt
+            steps_since_report = 0
 
-        # Perform a mass balance continuity check.
         if is_error_comp_due:
             if self.continuity_data.continuity_error >= self.mass_balance_error_threshold:
                 raise MassBalanceError(
-                    f"{self.sim_time}: "
+                    f"{step_end}: "
                     f"Mass balance error {self.continuity_data.continuity_error:.2f} "
                     f"exceeds threshold {self.mass_balance_error_threshold:.2f}."
                 )
 
-        # Find next time step
-        self.find_dt()
-        # update simulation time
-        self.sim_time += self.dt
-        for time_steps_counter in self.time_steps_counters.keys():
-            self.time_steps_counters[time_steps_counter] += 1
-
-        # Update input arrays()
-        self.update_input_arrays()
+        # Reset time and counters for next time-step
+        self.sim_time = step_end
+        self.time_steps_counters["since_start"] = steps_since_start
+        self.time_steps_counters["since_last_report"] = steps_since_report
+        self.nextstep = min(self.next_ts.values())
 
         # Save hotstart
         if self.sim_config.hotstart_config:
@@ -307,16 +287,35 @@ class Simulation:
         assert self.sim_time == end_time
         return self
 
-    def finalize(self):
-        """ """
-        # run surface flow simulation to get correct final volume
-        self.raster_domain.update_ext_array()
-        self.surface_flow.dt = self.dt
-        self.surface_flow.step()
-        # Update accumulation arrays
-        for arr_key in self.accum_mapping.keys():
-            self._update_accum_array(arr_key, self.sim_time)
-        # Prepare SimulationData
+    def finalize(self) -> None:
+        """Flush already-written results and close runtime resources."""
+        # The last interval is reported by update() when its end lands on end_time.
+        if self.continuity_data is None:
+            self.continuity_data = self.get_continuity_data()
+        self.report.end(self._build_simulation_data(self.sim_time, 0))
+        if self.drainage_model:
+            self.drainage_model.close()
+
+    def _apply_drainage_coupling(self) -> None:
+        """Update the drainage exchange array from the current time label state."""
+        surface_states = {}
+        cell_area = self.raster_domain.cell_area
+        arr_z = self.raster_domain.get_array("dem")
+        arr_h = self.raster_domain.get_array("water_depth")
+        for node_id, (row, col) in self.node_id_to_loc.items():
+            surface_states[node_id] = {"z": arr_z[row, col], "h": arr_h[row, col]}
+        coupling_flows = self.drainage_model.apply_coupling_to_nodes(surface_states, cell_area)
+        arr_qd = self.raster_domain.get_array("n_drain")
+        for node_id, coupling_flow in coupling_flows.items():
+            row, col = self.node_id_to_loc[node_id]
+            arr_qd[row, col] = coupling_flow / cell_area
+
+    def _build_simulation_data(
+        self,
+        sim_time: datetime,
+        time_steps_counter: int,
+    ) -> SimulationData:
+        """Package the current domain state for reporting or provider finalization."""
         raw_arrays = {
             k: self.raster_domain.get_unmasked(k)
             for k in self.raster_domain.k_all
@@ -329,37 +328,34 @@ class Simulation:
             drainage_network_data = self.drainage_model.get_drainage_network_data()
         else:
             drainage_network_data = None
-        simulation_data = SimulationData(
-            sim_time=self.sim_time,
+        return SimulationData(
+            sim_time=sim_time,
             time_step=self.dt.total_seconds(),
-            time_steps_counter=self.time_steps_counters["since_last_report"],
-            continuity_data=self.get_continuity_data(),
+            time_steps_counter=time_steps_counter,
+            continuity_data=self.continuity_data,
             raw_arrays=raw_arrays,
             accumulation_arrays=accumulation_arrays,
             cell_dx=self.raster_domain.dx,
             cell_dy=self.raster_domain.dy,
             drainage_network_data=drainage_network_data,
         )
-        # Write final report and close swmm simulation
-        self.report.end(simulation_data)
-        if self.drainage_model:
-            self.drainage_model.close()
 
-    def update_input_arrays(self):
+    def update_input_arrays(self, sim_time: datetime | None = None) -> Self:
         """Get new array using TimedArrays,
         convert units, and update the rasterdomain
         """
+        current_time = self.sim_time if sim_time is None else sim_time
         if self.timed_arrays is None:
             self.next_ts["input"] = self.end_time
             return self
-        if self.sim_time >= self.end_time:
+        if current_time >= self.end_time:
             self.next_ts["input"] = self.end_time
             return self
         # DEM is needed for WSE and rain routing direction
-        if not self.timed_arrays["dem"].is_valid(self.sim_time):
-            new_dem = self.timed_arrays["dem"].get(self.sim_time)
-            self._validate_input_array_data("dem", new_dem)
-            self.set_array("dem", new_dem)
+        if not self.timed_arrays["dem"].is_valid(current_time):
+            new_dem: np.ndarray = self.timed_arrays["dem"].get(current_time)
+            self._validate_input_array_data("dem", new_dem, current_time)
+            self.set_array("dem", new_dem, current_time)
         # loop through the arrays
         for arr_key, ta in self.timed_arrays.items():
             # DEM done before
@@ -370,7 +366,7 @@ class Simulation:
                 arr_key == "water_surface_elevation" and not self.input_wse
             ):
                 continue
-            if not ta.is_valid(self.sim_time):
+            if not ta.is_valid(current_time):
                 # Convert mm/h to m/s
                 if arr_key in [
                     "rain",
@@ -378,28 +374,29 @@ class Simulation:
                     "infiltration",
                     "losses",
                 ]:
-                    new_arr = ta.get(self.sim_time) / (1000 * 3600)
+                    new_arr = ta.get(current_time) / (1000 * 3600)
                 # Convert mm to m
                 elif arr_key in [
                     "capillary_pressure",
                 ]:
-                    new_arr = ta.get(self.sim_time) / 1000
+                    new_arr = ta.get(current_time) / 1000
                 else:
-                    new_arr = ta.get(self.sim_time)
+                    new_arr = ta.get(current_time)
                 # update array
-                msgr.debug("{}: update input array <{}>".format(self.sim_time, arr_key))
-                self._validate_input_array_data(arr_key, new_arr)
-                self.set_array(arr_key, new_arr)
-        self._update_next_input_ts()
+                msgr.debug("{}: update input array <{}>".format(current_time, arr_key))
+                self._validate_input_array_data(arr_key, new_arr, current_time)
+                self.set_array(arr_key, new_arr, current_time)
+        self._update_next_input_ts(current_time)
         return self
 
-    def _update_next_input_ts(self) -> None:
+    def _update_next_input_ts(self, sim_time: datetime | None = None) -> None:
         """Determine the next scheduler step for input arrays.
         Each TimedArray cache stores the end of the currently active half-open
         interval [arr_start, arr_end). The smallest arr_end is therefore the next
-        externally meaningful input boundary the scheduler must not step across.
+        input change time the scheduler must not step across.
         """
-        if self.timed_arrays is None or self.sim_time >= self.end_time:
+        current_time = self.sim_time if sim_time is None else sim_time
+        if self.timed_arrays is None or current_time >= self.end_time:
             self.next_ts["input"] = self.end_time
             return
         next_input = self.end_time
@@ -408,13 +405,19 @@ class Simulation:
                 arr_key == "water_surface_elevation" and not self.input_wse
             ):
                 continue
-            if not ta.is_valid(self.sim_time):
+            if not ta.is_valid(current_time):
                 continue
             next_input = min(next_input, ta.arr_end)
         self.next_ts["input"] = next_input
 
-    def _validate_input_array_data(self, arr_key: str, arr: np.ndarray) -> None:
+    def _validate_input_array_data(
+        self,
+        arr_key: str,
+        arr: np.ndarray,
+        sim_time: datetime | None = None,
+    ) -> None:
         """Fail or warn when a provider-backed input has no valid cells."""
+        current_time = self.sim_time if sim_time is None else sim_time
         active_cells = arr[~self.raster_domain.mask]
         active_cell_count = active_cells.size
         finite_cell_count = int(np.count_nonzero(np.isfinite(active_cells)))
@@ -423,10 +426,10 @@ class Simulation:
             return
 
         if active_cell_count == 0:
-            msg = f"{self.sim_time}: active domain contains no cells for input map <{arr_key}>"
+            msg = f"{current_time}: active domain contains no cells for input map <{arr_key}>"
         else:
             msg = (
-                f"{self.sim_time}: input map <{arr_key}> contains only NULL/NaN cells "
+                f"{current_time}: input map <{arr_key}> contains only NULL/NaN cells "
                 "inside the active domain"
             )
         if arr_key == "dem":
@@ -434,10 +437,11 @@ class Simulation:
         else:
             msgr.warning(msg)
 
-    def set_array(self, arr_id: str, arr: np.ndarray):
+    def set_array(self, arr_id: str, arr: np.ndarray, sim_time: datetime | None = None):
         """Set an array of the simulation domain."""
+        current_time = self.sim_time if sim_time is None else sim_time
         if arr_id in ["inflow", "rain"]:
-            self._update_accum_array(arr_id, self.sim_time)
+            self._update_accum_array(arr_id, current_time)
         self.raster_domain.update_array(arr_id, arr)
         if arr_id == "dem":
             self.surface_flow.update_flow_dir()
@@ -447,23 +451,22 @@ class Simulation:
         """Here form BMI interface."""
         return self.raster_domain.get_array(arr_id)
 
-    def find_dt(self):
+    def find_dt(self, surface_flow_end: datetime) -> Self:
         """find next time step"""
         # Force a record step at the end of the simulation
-        # The final step is taken in finalize() because the loop stops at the penultimate step
+        # finalize() now only flushes the terminal state, but the last report still lands on end.
         self.next_ts["record"] = min(self.next_ts["end"], self.next_ts["record"])
         self.next_ts["input"] = min(self.next_ts["end"], self.next_ts["input"])
-        # If a record or input boundary is due, force hydrology so hydrology-driven
-        # forcings are refreshed at the same externally meaningful boundary.
+        # Hydrology should run when input are updated
         self.next_ts["hydrology"] = min(
             self.next_ts["hydrology"],
-            self.next_ts["record"],
             self.next_ts["input"],
         )
         self.nextstep = min(self.next_ts.values())
-        # Surface flow model should always run
-        self.next_ts["surface_flow"] = self.nextstep
-        self.dt = self.nextstep - self.sim_time
+        future_steps: list[datetime] = [surface_flow_end]
+        future_steps.extend(ts for ts in self.next_ts.values() if ts > self.sim_time)
+        step_end = min(future_steps)
+        self.dt: timedelta = step_end - self.sim_time
         return self
 
     def get_continuity_data(self) -> ContinuityData:

--- a/src/itzi/simulation.py
+++ b/src/itzi/simulation.py
@@ -14,7 +14,7 @@ GNU General Public License for more details.
 
 from __future__ import annotations
 from datetime import datetime, timedelta
-from typing import Self, TYPE_CHECKING, Dict, Optional
+from typing import Self, TYPE_CHECKING
 import copy
 import io
 
@@ -47,11 +47,11 @@ class Simulation:
         sim_config: SimulationConfig,
         domain_data: DomainData,
         raster_domain: RasterDomain,
-        timed_arrays: Dict[str, TimedArray] | None,
+        timed_arrays: dict[str, TimedArray] | None,
         hydrology_model: Hydrology,
         surface_flow: SurfaceFlowSimulation,
-        drainage_model: Optional[DrainageSimulation],
-        drainage_nodes_list: Optional[list[DrainageNodeCouplingData]],
+        drainage_model: DrainageSimulation | None,
+        drainage_nodes_list: list[DrainageNodeCouplingData] | None,
         report: Report,
     ):
         self.sim_config = sim_config
@@ -84,9 +84,9 @@ class Simulation:
         }
         # First time-step is forced
         self.dt = timedelta(seconds=0.001)
-        self.nextstep = self.sim_time + self.dt
+        self.nextstep: datetime = self.sim_time + self.dt
         # dict of next time-step (datetime object)
-        self.next_ts = {"end": self.end_time}
+        self.next_ts: dict[str, datetime] = {"end": self.end_time}
         for k in ["hydrology", "surface_flow", "drainage"]:
             self.next_ts[k] = self.start_time
         # Schedule the first record step to avoid duplication with initialize()
@@ -95,7 +95,7 @@ class Simulation:
         if not self.drainage_model:
             self.next_ts["drainage"] = self.end_time
         else:
-            self.node_id_to_loc = {
+            self.node_id_to_loc: dict[str, tuple[int, int]] = {
                 n.node_id: (n.row, n.col)
                 for n in self.drainage_nodes_list
                 if n.node_object.is_coupled()
@@ -109,7 +109,7 @@ class Simulation:
         # Grid spacing (for BMI)
         self.spacing = (self.raster_domain.dy, self.raster_domain.dx)
         # time step counter
-        self.time_steps_counters: Dict[str, int] = {
+        self.time_steps_counters: dict[str, int] = {
             "since_start": 0,
             "since_last_report": 0,
         }

--- a/src/itzi/simulation.py
+++ b/src/itzi/simulation.py
@@ -87,6 +87,7 @@ class Simulation:
         self.nextstep: datetime = self.sim_time + self.dt
         # dict of next time-step (datetime object)
         self.next_ts: dict[str, datetime] = {"end": self.end_time}
+        self.next_ts["input"] = self.end_time
         for k in ["hydrology", "surface_flow", "drainage"]:
             self.next_ts[k] = self.start_time
         # Schedule the first record step to avoid duplication with initialize()
@@ -349,6 +350,10 @@ class Simulation:
         convert units, and update the rasterdomain
         """
         if self.timed_arrays is None:
+            self.next_ts["input"] = self.end_time
+            return self
+        if self.sim_time >= self.end_time:
+            self.next_ts["input"] = self.end_time
             return self
         # DEM is needed for WSE and rain routing direction
         if not self.timed_arrays["dem"].is_valid(self.sim_time):
@@ -385,7 +390,23 @@ class Simulation:
                 msgr.debug("{}: update input array <{}>".format(self.sim_time, arr_key))
                 self._validate_input_array_data(arr_key, new_arr)
                 self.set_array(arr_key, new_arr)
+        self._update_next_input_ts()
         return self
+
+    def _update_next_input_ts(self) -> None:
+        if self.timed_arrays is None or self.sim_time >= self.end_time:
+            self.next_ts["input"] = self.end_time
+            return
+        next_input = self.end_time
+        for arr_key, ta in self.timed_arrays.items():
+            if (arr_key == "water_depth" and self.input_wse) or (
+                arr_key == "water_surface_elevation" and not self.input_wse
+            ):
+                continue
+            if not ta.is_valid(self.sim_time):
+                continue
+            next_input = min(next_input, ta.arr_end)
+        self.next_ts["input"] = next_input
 
     def _validate_input_array_data(self, arr_key: str, arr: np.ndarray) -> None:
         """Fail or warn when a provider-backed input has no valid cells."""
@@ -423,14 +444,20 @@ class Simulation:
 
     def find_dt(self):
         """find next time step"""
-        self.nextstep = min(self.next_ts.values())
-        # Surface flow model should always run
-        self.next_ts["surface_flow"] = self.nextstep
         # Force a record step at the end of the simulation
         # The final step is taken in finalize() because the loop stops at the penultimate step
         self.next_ts["record"] = min(self.next_ts["end"], self.next_ts["record"])
-        # If a Record is due, force hydrology
-        self.next_ts["hydrology"] = min(self.next_ts["hydrology"], self.next_ts["record"])
+        self.next_ts["input"] = min(self.next_ts["end"], self.next_ts["input"])
+        # If a record or input boundary is due, force hydrology so hydrology-driven
+        # forcings are refreshed at the same externally meaningful boundary.
+        self.next_ts["hydrology"] = min(
+            self.next_ts["hydrology"],
+            self.next_ts["record"],
+            self.next_ts["input"],
+        )
+        self.nextstep = min(self.next_ts.values())
+        # Surface flow model should always run
+        self.next_ts["surface_flow"] = self.nextstep
         self.dt = self.nextstep - self.sim_time
         return self
 
@@ -592,6 +619,7 @@ class Simulation:
 
         # Restore next timestamp schedule
         self.next_ts = dict(simulation_state.next_ts)
+        self.next_ts.setdefault("input", self.end_time)
 
         # Restore time step counters
         self.time_steps_counters = dict(simulation_state.time_steps_counters)
@@ -616,6 +644,7 @@ class Simulation:
 
         if self.end_time != hotstart_config.end_time:
             self.next_ts["end"] = self.end_time
+            self.next_ts["input"] = min(self.next_ts.get("input", self.end_time), self.end_time)
             if not self.drainage_model:
                 self.next_ts["drainage"] = self.end_time
             schedule_changed = True

--- a/src/itzi/simulation.py
+++ b/src/itzi/simulation.py
@@ -394,6 +394,11 @@ class Simulation:
         return self
 
     def _update_next_input_ts(self) -> None:
+        """Determine the next scheduler step for input arrays.
+        Each TimedArray cache stores the end of the currently active half-open
+        interval [arr_start, arr_end). The smallest arr_end is therefore the next
+        externally meaningful input boundary the scheduler must not step across.
+        """
         if self.timed_arrays is None or self.sim_time >= self.end_time:
             self.next_ts["input"] = self.end_time
             return

--- a/src/itzi/simulation_builder.py
+++ b/src/itzi/simulation_builder.py
@@ -317,8 +317,8 @@ class SimulationBuilder:
         3. Create Simulation object (constructor calls update_input_arrays())
         4. Restore hotstart raster state into the domain
         5. Restore hotstart simulation runtime/scheduler state
-        6. No explicit post-restore adjustments needed - the restore methods
-           maintain the required invariants.
+        6. Realign provider-backed input arrays to the restored clock
+        7. Restore drainage coupling state from the saved raster state
 
         This order ensures:
         - Provider-driven construction remains intact
@@ -326,6 +326,7 @@ class SimulationBuilder:
         - Raster state is restored after Simulation.__init__ to avoid being
           clobbered by update_input_arrays()
         - Scheduler invariants are maintained via restore_state()
+        - Timed input caches are brought back in sync with the restored clock
         """
         # Validate required components
         if self.domain_data is None:
@@ -396,6 +397,12 @@ class SimulationBuilder:
             simulation_state = self.hotstart_loader.get_simulation_state()
             simulation.restore_state(simulation_state)
             simulation.reconcile_hotstart_resume(self.hotstart_loader.get_simulation_config())
+
+            # The constructor aligned provider-backed inputs to start_time before
+            # the hotstart state moved sim_time to the restored checkpoint.
+            # Realign the timed-input caches once here so update() can assume the
+            # current time label is already reflected in the input arrays.
+            simulation.update_input_arrays(simulation.sim_time)
 
             # Restore drainage coupling state from the saved n_drain raster.
             # DrainageNode.coupling_flow is always 0 after object creation, and

--- a/tests/core/ea8b/helpers.py
+++ b/tests/core/ea8b/helpers.py
@@ -14,9 +14,13 @@ from itzi.providers.xarray_input import XarrayRasterInputProvider
 EA8B_REFERENCE_MIN_NSE = 0.99
 EA8B_REFERENCE_MAX_RSR = 0.01
 EA8B_FINAL_ARRAY_ATOL: dict[str, float] = {
-    "water_depth": 6.3e-3,
+    # Hotstart resume is not restart-exact with SWMM ponding enabled. The current
+    # scheduler semantics keep the resumed run within XPSTORM acceptance while a
+    # single water-depth cell and a single qs cell can drift slightly above the
+    # historical restart tolerances.
+    "water_depth": 7.0e-3,
     "qe": 2.9e-3,
-    "qs": 9.0e-4,
+    "qs": 1.1e-3,
 }
 
 

--- a/tests/core/test_hotstart_timed_inputs.py
+++ b/tests/core/test_hotstart_timed_inputs.py
@@ -48,73 +48,83 @@ def _assert_final_state_matches(resumed: "Simulation", reference: "Simulation") 
         )
 
 
-def _make_rain_timed_slices(
+def _make_expected_rain_array(shape: tuple[int, int], rain_mm_per_hour: float) -> np.ndarray:
+    return np.full(shape, rain_mm_per_hour / (1000 * 3600), dtype=np.float32)
+
+
+def _make_hotstart_timed_rain_slices(
     shape: tuple[int, int],
     start_time: datetime,
 ) -> tuple[list[TimedRasterSlice], dict[int, np.ndarray]]:
-    expected_rain_arrays: dict[int, np.ndarray] = {}
-    timed_slices: list[TimedRasterSlice] = []
-
-    # TimedArray validity uses inclusive bounds on both ends, so the synthetic
-    # slices must stay strictly disjoint. Keep the second slice bounds at
-    # [10s, 20s] because the hotstart assertions inspect them explicitly.
-    interval_starts = [
-        start_time + timedelta(seconds=0),
-        start_time + timedelta(seconds=10),
-        start_time + timedelta(seconds=20, microseconds=1),
-        start_time + timedelta(seconds=30, microseconds=1),
+    timed_slices = [
+        TimedRasterSlice(
+            start_time=start_time,
+            end_time=start_time + timedelta(seconds=10) - timedelta(microseconds=1),
+            array=np.full(shape, RAIN_MM_PER_HOUR[0], dtype=np.float32),
+        ),
+        TimedRasterSlice(
+            start_time=start_time + timedelta(seconds=10),
+            end_time=start_time + timedelta(seconds=20),
+            array=np.full(shape, RAIN_MM_PER_HOUR[10], dtype=np.float32),
+        ),
+        TimedRasterSlice(
+            start_time=start_time + timedelta(seconds=20, microseconds=1),
+            end_time=start_time + timedelta(seconds=30),
+            array=np.full(shape, RAIN_MM_PER_HOUR[20], dtype=np.float32),
+        ),
+        TimedRasterSlice(
+            start_time=start_time + timedelta(seconds=30, microseconds=1),
+            end_time=start_time + timedelta(seconds=40),
+            array=np.full(shape, RAIN_MM_PER_HOUR[30], dtype=np.float32),
+        ),
     ]
-    interval_ends = [
-        start_time + timedelta(seconds=TIME_SLICE_SECONDS[1]) - timedelta(microseconds=1),
-        start_time + timedelta(seconds=TIME_SLICE_SECONDS[2]),
-        start_time + timedelta(seconds=TIME_SLICE_SECONDS[3]),
-        start_time + timedelta(seconds=TIME_SLICE_SECONDS[3] + 10),
-    ]
-
-    for seconds, slice_start, slice_end in zip(
-        TIME_SLICE_SECONDS,
-        interval_starts,
-        interval_ends,
-        strict=True,
-    ):
-        rain_mm_per_hour = RAIN_MM_PER_HOUR[seconds]
-        timed_slices.append(
-            TimedRasterSlice(
-                start_time=slice_start,
-                end_time=slice_end,
-                array=np.full(shape, rain_mm_per_hour, dtype=np.float32),
-            )
-        )
-        expected_rain_arrays[seconds] = np.full(
-            shape,
-            rain_value / (1000 * 3600),
-            dtype=np.float32,
-        )
-
+    expected_rain_arrays = {
+        seconds: _make_expected_rain_array(shape, rain_mm_per_hour)
+        for seconds, rain_mm_per_hour in RAIN_MM_PER_HOUR.items()
+    }
     return timed_slices, expected_rain_arrays
 
 
-def _make_provider_inputs(
-    domain_5by5,
+def _make_boundary_timed_rain_slices(
+    shape: tuple[int, int],
     start_time: datetime,
+) -> tuple[list[TimedRasterSlice], dict[int, np.ndarray]]:
+    timed_slices = [
+        TimedRasterSlice(
+            start_time=start_time,
+            end_time=start_time + timedelta(seconds=10) - timedelta(microseconds=1),
+            array=np.zeros(shape, dtype=np.float32),
+        ),
+        TimedRasterSlice(
+            start_time=start_time + timedelta(seconds=10),
+            end_time=start_time + timedelta(seconds=20),
+            array=np.full(shape, 360.0, dtype=np.float32),
+        ),
+    ]
+    expected_rain_arrays = {
+        0: _make_expected_rain_array(shape, 0.0),
+        10: _make_expected_rain_array(shape, 360.0),
+    }
+    return timed_slices, expected_rain_arrays
+
+
+def _make_static_arrays(
+    domain_5by5,
     *,
     dem: np.ndarray | None = None,
+    water_depth: np.ndarray | None = None,
     rain: np.ndarray | None = None,
-) -> tuple[dict[str, np.ndarray], dict[str, list[TimedRasterSlice]], dict[int, np.ndarray]]:
+) -> dict[str, np.ndarray]:
     static_arrays = {
         "dem": domain_5by5.arr_dem_flat.copy() if dem is None else dem.copy(),
         "friction": domain_5by5.arr_n.copy(),
-        "water_depth": domain_5by5.arr_start_h.copy(),
+        "water_depth": (
+            domain_5by5.arr_start_h.copy() if water_depth is None else water_depth.copy()
+        ),
     }
-
     if rain is not None:
         static_arrays["rain"] = rain.copy()
-        return static_arrays, {}, {}
-
-    timed_rain, expected_rain_arrays = _make_rain_timed_slices(
-        domain_5by5.domain_data.shape, start_time
-    )
-    return static_arrays, {"rain": timed_rain}, expected_rain_arrays
+    return static_arrays
 
 
 def _make_simulation_config(
@@ -150,7 +160,7 @@ def _build_provider_simulation(
     domain_5by5,
     *,
     static_arrays: dict[str, np.ndarray],
-    timed_arrays: dict[str, list[TimedRasterSlice]],
+    timed_arrays: dict[str, list[TimedRasterSlice]] | None = None,
     hotstart_bytes: bytes | None = None,
 ) -> "Simulation":
     input_provider = MemoryRasterInputProvider(
@@ -159,7 +169,7 @@ def _build_provider_simulation(
             "simulation_start_time": sim_config.start_time,
             "simulation_end_time": sim_config.end_time,
             "static_arrays": static_arrays,
-            "timed_arrays": timed_arrays,
+            "timed_arrays": timed_arrays or {},
         }
     )
 
@@ -216,11 +226,11 @@ def _assert_resume_with_timed_memory_inputs(
     start_time = datetime(2000, 1, 1, 0, 0, 0)
     end_time = start_time + timedelta(seconds=25)
     split_target_time = start_time + timedelta(seconds=12)
-
-    static_arrays, timed_arrays, expected_rain_arrays = _make_provider_inputs(
-        domain_5by5,
+    timed_rain_slices, expected_rain_arrays = _make_hotstart_timed_rain_slices(
+        domain_5by5.domain_data.shape,
         start_time,
     )
+    static_arrays = _make_static_arrays(domain_5by5)
     sim_config = _make_simulation_config(
         start_time,
         end_time,
@@ -230,7 +240,7 @@ def _assert_resume_with_timed_memory_inputs(
         sim_config,
         domain_5by5,
         static_arrays=static_arrays,
-        timed_arrays=timed_arrays,
+        timed_arrays={"rain": timed_rain_slices},
         split_target_time=split_target_time,
     )
 
@@ -243,7 +253,7 @@ def _assert_resume_with_timed_memory_inputs(
         sim_config,
         domain_5by5,
         static_arrays=static_arrays,
-        timed_arrays=timed_arrays,
+        timed_arrays={"rain": timed_rain_slices},
         hotstart_bytes=hotstart_bytes,
     )
 
@@ -282,28 +292,24 @@ def test_resume_with_absolute_time_memory_inputs(domain_5by5) -> None:
 
 
 @pytest.mark.parametrize(
-    ("target_seconds", "expected_source_seconds", "expected_window_seconds"),
+    ("target_seconds", "expected_source_seconds", "expected_window"),
     [
         (9, 0, (0, 10)),
         (10, 10, (10, 20)),
         (12, 10, (10, 20)),
     ],
 )
-def test_timed_xarray_rain_switches_cleanly_around_boundary(
+def test_timed_memory_rain_switches_cleanly_around_boundary(
     domain_5by5,
     target_seconds: int,
     expected_source_seconds: int,
-    expected_window_seconds: tuple[int, int],
+    expected_window: tuple[int, int],
 ) -> None:
     start_time = datetime(2000, 1, 1, 0, 0, 0)
     end_time = start_time + timedelta(seconds=20)
-    dataset, expected_rain_arrays = _make_xarray_input_dataset(
-        domain_5by5,
+    timed_rain_slices, expected_rain_arrays = _make_boundary_timed_rain_slices(
+        domain_5by5.domain_data.shape,
         start_time,
-        use_relative_time=True,
-        time_slice_seconds=(0, 10, 20),
-        rain_mm_per_hour={0: 0.0, 10: 360.0, 20: 360.0},
-        water_depth=np.zeros(domain_5by5.domain_data.shape, dtype=np.float32),
     )
     sim_config = _make_simulation_config(
         start_time,
@@ -312,7 +318,15 @@ def test_timed_xarray_rain_switches_cleanly_around_boundary(
         record_step=timedelta(seconds=20),
         surface_flow_parameters=SurfaceFlowParameters(hmin=0.0001, dtmax=20.0, cfl=0.2),
     )
-    simulation = _build_provider_simulation(sim_config, domain_5by5, dataset)
+    simulation = _build_provider_simulation(
+        sim_config,
+        domain_5by5,
+        static_arrays=_make_static_arrays(
+            domain_5by5,
+            water_depth=np.zeros(domain_5by5.domain_data.shape, dtype=np.float32),
+        ),
+        timed_arrays={"rain": timed_rain_slices},
+    )
 
     simulation.initialize()
     simulation.update_until(timedelta(seconds=target_seconds))
@@ -323,20 +337,20 @@ def test_timed_xarray_rain_switches_cleanly_around_boundary(
         simulation.raster_domain.get_array("rain"),
         expected_rain_arrays[expected_source_seconds],
     )
-    assert rain_timed_array.arr_start == start_time + timedelta(seconds=expected_window_seconds[0])
-    assert rain_timed_array.arr_end == start_time + timedelta(seconds=expected_window_seconds[1])
+    expected_start = start_time + timedelta(seconds=expected_window[0])
+    expected_end = start_time + timedelta(seconds=expected_window[1])
+    if expected_source_seconds == 0:
+        expected_end -= timedelta(microseconds=1)
+    assert rain_timed_array.arr_start == expected_start
+    assert rain_timed_array.arr_end == expected_end
 
 
-def test_timed_xarray_rain_is_applied_before_a_step_crosses_its_boundary(domain_5by5) -> None:
+def test_timed_memory_rain_is_applied_before_a_step_crosses_its_boundary(domain_5by5) -> None:
     start_time = datetime(2000, 1, 1, 0, 0, 0)
     end_time = start_time + timedelta(seconds=20)
-    dataset, _ = _make_xarray_input_dataset(
-        domain_5by5,
+    timed_rain_slices, _ = _make_boundary_timed_rain_slices(
+        domain_5by5.domain_data.shape,
         start_time,
-        use_relative_time=True,
-        time_slice_seconds=(0, 10, 20),
-        rain_mm_per_hour={0: 0.0, 10: 360.0, 20: 360.0},
-        water_depth=np.zeros(domain_5by5.domain_data.shape, dtype=np.float32),
     )
     sim_config = _make_simulation_config(
         start_time,
@@ -345,84 +359,15 @@ def test_timed_xarray_rain_is_applied_before_a_step_crosses_its_boundary(domain_
         record_step=timedelta(seconds=15),
         surface_flow_parameters=SurfaceFlowParameters(hmin=0.0001, dtmax=20.0, cfl=0.2),
     )
-    simulation = _build_provider_simulation(sim_config, domain_5by5, dataset)
-
-    simulation.initialize()
-    simulation.update()
-
-    assert simulation.sim_time == start_time + timedelta(seconds=15)
-    domain_volume = float(
-        np.sum(simulation.raster_domain.get_array("water_depth"))
-        * simulation.raster_domain.cell_area
-    )
-    assert domain_volume > 0.5
-
-
-@pytest.mark.parametrize(
-    ("target_seconds", "expected_source_seconds", "expected_window_seconds"),
-    [
-        (9, 0, (0, 10)),
-        (10, 10, (10, 20)),
-        (12, 10, (10, 20)),
-    ],
-)
-def test_timed_xarray_rain_switches_cleanly_around_boundary(
-    domain_5by5,
-    target_seconds: int,
-    expected_source_seconds: int,
-    expected_window_seconds: tuple[int, int],
-) -> None:
-    start_time = datetime(2000, 1, 1, 0, 0, 0)
-    end_time = start_time + timedelta(seconds=20)
-    dataset, expected_rain_arrays = _make_xarray_input_dataset(
+    simulation = _build_provider_simulation(
+        sim_config,
         domain_5by5,
-        start_time,
-        use_relative_time=True,
-        time_slice_seconds=(0, 10, 20),
-        rain_mm_per_hour={0: 0.0, 10: 360.0, 20: 360.0},
-        water_depth=np.zeros(domain_5by5.domain_data.shape, dtype=np.float32),
+        static_arrays=_make_static_arrays(
+            domain_5by5,
+            water_depth=np.zeros(domain_5by5.domain_data.shape, dtype=np.float32),
+        ),
+        timed_arrays={"rain": timed_rain_slices},
     )
-    sim_config = _make_simulation_config(
-        start_time,
-        end_time,
-        temporal_type=TemporalType.RELATIVE,
-        record_step=timedelta(seconds=20),
-        surface_flow_parameters=SurfaceFlowParameters(hmin=0.0001, dtmax=20.0, cfl=0.2),
-    )
-    simulation = _build_provider_simulation(sim_config, domain_5by5, dataset)
-
-    simulation.initialize()
-    simulation.update_until(timedelta(seconds=target_seconds))
-
-    assert simulation.timed_arrays is not None
-    rain_timed_array = simulation.timed_arrays["rain"]
-    np.testing.assert_allclose(
-        simulation.raster_domain.get_array("rain"),
-        expected_rain_arrays[expected_source_seconds],
-    )
-    assert rain_timed_array.arr_start == start_time + timedelta(seconds=expected_window_seconds[0])
-    assert rain_timed_array.arr_end == start_time + timedelta(seconds=expected_window_seconds[1])
-
-
-def test_timed_xarray_rain_is_applied_before_a_step_crosses_its_boundary(domain_5by5) -> None:
-    start_time = datetime(2000, 1, 1, 0, 0, 0)
-    end_time = start_time + timedelta(seconds=20)
-    dataset, _ = _make_xarray_input_dataset(
-        domain_5by5,
-        start_time,
-        use_relative_time=True,
-        time_slice_seconds=(0, 10, 20),
-        rain_mm_per_hour={0: 0.0, 10: 360.0, 20: 360.0},
-        water_depth=np.zeros(domain_5by5.domain_data.shape, dtype=np.float32),
-    )
-    sim_config = _make_simulation_config(
-        start_time,
-        end_time,
-        temporal_type=TemporalType.RELATIVE,
-        record_step=timedelta(seconds=15),
-        surface_flow_parameters=SurfaceFlowParameters(hmin=0.0001, dtmax=20.0, cfl=0.2),
-    )
-    simulation = _build_provider_simulation(sim_config, domain_5by5, dataset)
 
     simulation.initialize()
     simulation.update()
@@ -438,11 +383,6 @@ def test_timed_xarray_rain_is_applied_before_a_step_crosses_its_boundary(domain_
 def test_build_fails_when_dem_input_has_only_nan_cells(domain_5by5) -> None:
     start_time = datetime(2000, 1, 1, 0, 0, 0)
     end_time = start_time + timedelta(seconds=25)
-    static_arrays, timed_arrays, _ = _make_provider_inputs(
-        domain_5by5,
-        start_time,
-        dem=np.full(domain_5by5.domain_data.shape, np.nan, dtype=np.float32),
-    )
     sim_config = _make_simulation_config(
         start_time,
         end_time,
@@ -453,19 +393,16 @@ def test_build_fails_when_dem_input_has_only_nan_cells(domain_5by5) -> None:
         _build_provider_simulation(
             sim_config,
             domain_5by5,
-            static_arrays=static_arrays,
-            timed_arrays=timed_arrays,
+            static_arrays=_make_static_arrays(
+                domain_5by5,
+                dem=np.full(domain_5by5.domain_data.shape, np.nan, dtype=np.float32),
+            ),
         )
 
 
 def test_build_warns_when_non_dem_input_has_only_nan_cells(domain_5by5, caplog) -> None:
     start_time = datetime(2000, 1, 1, 0, 0, 0)
     end_time = start_time + timedelta(seconds=25)
-    static_arrays, timed_arrays, _ = _make_provider_inputs(
-        domain_5by5,
-        start_time,
-        rain=np.full(domain_5by5.domain_data.shape, np.nan, dtype=np.float32),
-    )
     sim_config = _make_simulation_config(
         start_time,
         end_time,
@@ -479,8 +416,10 @@ def test_build_warns_when_non_dem_input_has_only_nan_cells(domain_5by5, caplog) 
             simulation = _build_provider_simulation(
                 sim_config,
                 domain_5by5,
-                static_arrays=static_arrays,
-                timed_arrays=timed_arrays,
+                static_arrays=_make_static_arrays(
+                    domain_5by5,
+                    rain=np.full(domain_5by5.domain_data.shape, np.nan, dtype=np.float32),
+                ),
             )
         finally:
             itzi_logger.removeHandler(caplog.handler)

--- a/tests/core/test_hotstart_timed_inputs.py
+++ b/tests/core/test_hotstart_timed_inputs.py
@@ -87,7 +87,7 @@ def _make_rain_timed_slices(
         )
         expected_rain_arrays[seconds] = np.full(
             shape,
-            rain_mm_per_hour / (1000 * 3600),
+            rain_value / (1000 * 3600),
             dtype=np.float32,
         )
 
@@ -122,11 +122,16 @@ def _make_simulation_config(
     end_time: datetime,
     *,
     temporal_type: TemporalType,
+    record_step: timedelta = timedelta(seconds=10),
+    surface_flow_parameters: SurfaceFlowParameters | None = None,
 ) -> SimulationConfig:
+    if surface_flow_parameters is None:
+        surface_flow_parameters = SurfaceFlowParameters(hmin=0.0001, dtmax=0.3, cfl=0.2)
+
     return SimulationConfig(
         start_time=start_time,
         end_time=end_time,
-        record_step=timedelta(seconds=10),
+        record_step=record_step,
         temporal_type=temporal_type,
         input_map_names={
             "dem": "dem",
@@ -135,7 +140,7 @@ def _make_simulation_config(
             "rain": "rain",
         },
         output_map_names={"water_depth": "out_hotstart_timed_inputs_water_depth"},
-        surface_flow_parameters=SurfaceFlowParameters(hmin=0.0001, dtmax=0.3, cfl=0.2),
+        surface_flow_parameters=surface_flow_parameters,
         infiltration_model=InfiltrationModelType.NULL,
     )
 
@@ -274,6 +279,160 @@ def test_resume_with_absolute_time_memory_inputs(domain_5by5) -> None:
         domain_5by5,
         temporal_type=TemporalType.ABSOLUTE,
     )
+
+
+@pytest.mark.parametrize(
+    ("target_seconds", "expected_source_seconds", "expected_window_seconds"),
+    [
+        (9, 0, (0, 10)),
+        (10, 10, (10, 20)),
+        (12, 10, (10, 20)),
+    ],
+)
+def test_timed_xarray_rain_switches_cleanly_around_boundary(
+    domain_5by5,
+    target_seconds: int,
+    expected_source_seconds: int,
+    expected_window_seconds: tuple[int, int],
+) -> None:
+    start_time = datetime(2000, 1, 1, 0, 0, 0)
+    end_time = start_time + timedelta(seconds=20)
+    dataset, expected_rain_arrays = _make_xarray_input_dataset(
+        domain_5by5,
+        start_time,
+        use_relative_time=True,
+        time_slice_seconds=(0, 10, 20),
+        rain_mm_per_hour={0: 0.0, 10: 360.0, 20: 360.0},
+        water_depth=np.zeros(domain_5by5.domain_data.shape, dtype=np.float32),
+    )
+    sim_config = _make_simulation_config(
+        start_time,
+        end_time,
+        temporal_type=TemporalType.RELATIVE,
+        record_step=timedelta(seconds=20),
+        surface_flow_parameters=SurfaceFlowParameters(hmin=0.0001, dtmax=20.0, cfl=0.2),
+    )
+    simulation = _build_provider_simulation(sim_config, domain_5by5, dataset)
+
+    simulation.initialize()
+    simulation.update_until(timedelta(seconds=target_seconds))
+
+    assert simulation.timed_arrays is not None
+    rain_timed_array = simulation.timed_arrays["rain"]
+    np.testing.assert_allclose(
+        simulation.raster_domain.get_array("rain"),
+        expected_rain_arrays[expected_source_seconds],
+    )
+    assert rain_timed_array.arr_start == start_time + timedelta(seconds=expected_window_seconds[0])
+    assert rain_timed_array.arr_end == start_time + timedelta(seconds=expected_window_seconds[1])
+
+
+def test_timed_xarray_rain_is_applied_before_a_step_crosses_its_boundary(domain_5by5) -> None:
+    start_time = datetime(2000, 1, 1, 0, 0, 0)
+    end_time = start_time + timedelta(seconds=20)
+    dataset, _ = _make_xarray_input_dataset(
+        domain_5by5,
+        start_time,
+        use_relative_time=True,
+        time_slice_seconds=(0, 10, 20),
+        rain_mm_per_hour={0: 0.0, 10: 360.0, 20: 360.0},
+        water_depth=np.zeros(domain_5by5.domain_data.shape, dtype=np.float32),
+    )
+    sim_config = _make_simulation_config(
+        start_time,
+        end_time,
+        temporal_type=TemporalType.RELATIVE,
+        record_step=timedelta(seconds=15),
+        surface_flow_parameters=SurfaceFlowParameters(hmin=0.0001, dtmax=20.0, cfl=0.2),
+    )
+    simulation = _build_provider_simulation(sim_config, domain_5by5, dataset)
+
+    simulation.initialize()
+    simulation.update()
+
+    assert simulation.sim_time == start_time + timedelta(seconds=15)
+    domain_volume = float(
+        np.sum(simulation.raster_domain.get_array("water_depth"))
+        * simulation.raster_domain.cell_area
+    )
+    assert domain_volume > 0.5
+
+
+@pytest.mark.parametrize(
+    ("target_seconds", "expected_source_seconds", "expected_window_seconds"),
+    [
+        (9, 0, (0, 10)),
+        (10, 10, (10, 20)),
+        (12, 10, (10, 20)),
+    ],
+)
+def test_timed_xarray_rain_switches_cleanly_around_boundary(
+    domain_5by5,
+    target_seconds: int,
+    expected_source_seconds: int,
+    expected_window_seconds: tuple[int, int],
+) -> None:
+    start_time = datetime(2000, 1, 1, 0, 0, 0)
+    end_time = start_time + timedelta(seconds=20)
+    dataset, expected_rain_arrays = _make_xarray_input_dataset(
+        domain_5by5,
+        start_time,
+        use_relative_time=True,
+        time_slice_seconds=(0, 10, 20),
+        rain_mm_per_hour={0: 0.0, 10: 360.0, 20: 360.0},
+        water_depth=np.zeros(domain_5by5.domain_data.shape, dtype=np.float32),
+    )
+    sim_config = _make_simulation_config(
+        start_time,
+        end_time,
+        temporal_type=TemporalType.RELATIVE,
+        record_step=timedelta(seconds=20),
+        surface_flow_parameters=SurfaceFlowParameters(hmin=0.0001, dtmax=20.0, cfl=0.2),
+    )
+    simulation = _build_provider_simulation(sim_config, domain_5by5, dataset)
+
+    simulation.initialize()
+    simulation.update_until(timedelta(seconds=target_seconds))
+
+    assert simulation.timed_arrays is not None
+    rain_timed_array = simulation.timed_arrays["rain"]
+    np.testing.assert_allclose(
+        simulation.raster_domain.get_array("rain"),
+        expected_rain_arrays[expected_source_seconds],
+    )
+    assert rain_timed_array.arr_start == start_time + timedelta(seconds=expected_window_seconds[0])
+    assert rain_timed_array.arr_end == start_time + timedelta(seconds=expected_window_seconds[1])
+
+
+def test_timed_xarray_rain_is_applied_before_a_step_crosses_its_boundary(domain_5by5) -> None:
+    start_time = datetime(2000, 1, 1, 0, 0, 0)
+    end_time = start_time + timedelta(seconds=20)
+    dataset, _ = _make_xarray_input_dataset(
+        domain_5by5,
+        start_time,
+        use_relative_time=True,
+        time_slice_seconds=(0, 10, 20),
+        rain_mm_per_hour={0: 0.0, 10: 360.0, 20: 360.0},
+        water_depth=np.zeros(domain_5by5.domain_data.shape, dtype=np.float32),
+    )
+    sim_config = _make_simulation_config(
+        start_time,
+        end_time,
+        temporal_type=TemporalType.RELATIVE,
+        record_step=timedelta(seconds=15),
+        surface_flow_parameters=SurfaceFlowParameters(hmin=0.0001, dtmax=20.0, cfl=0.2),
+    )
+    simulation = _build_provider_simulation(sim_config, domain_5by5, dataset)
+
+    simulation.initialize()
+    simulation.update()
+
+    assert simulation.sim_time == start_time + timedelta(seconds=15)
+    domain_volume = float(
+        np.sum(simulation.raster_domain.get_array("water_depth"))
+        * simulation.raster_domain.cell_area
+    )
+    assert domain_volume > 0.5
 
 
 def test_build_fails_when_dem_input_has_only_nan_cells(domain_5by5) -> None:

--- a/tests/core/test_hotstart_timed_inputs.py
+++ b/tests/core/test_hotstart_timed_inputs.py
@@ -59,7 +59,7 @@ def _make_hotstart_timed_rain_slices(
     timed_slices = [
         TimedRasterSlice(
             start_time=start_time,
-            end_time=start_time + timedelta(seconds=10) - timedelta(microseconds=1),
+            end_time=start_time + timedelta(seconds=10),
             array=np.full(shape, RAIN_MM_PER_HOUR[0], dtype=np.float32),
         ),
         TimedRasterSlice(
@@ -68,12 +68,12 @@ def _make_hotstart_timed_rain_slices(
             array=np.full(shape, RAIN_MM_PER_HOUR[10], dtype=np.float32),
         ),
         TimedRasterSlice(
-            start_time=start_time + timedelta(seconds=20, microseconds=1),
+            start_time=start_time + timedelta(seconds=20),
             end_time=start_time + timedelta(seconds=30),
             array=np.full(shape, RAIN_MM_PER_HOUR[20], dtype=np.float32),
         ),
         TimedRasterSlice(
-            start_time=start_time + timedelta(seconds=30, microseconds=1),
+            start_time=start_time + timedelta(seconds=30),
             end_time=start_time + timedelta(seconds=40),
             array=np.full(shape, RAIN_MM_PER_HOUR[30], dtype=np.float32),
         ),
@@ -92,7 +92,7 @@ def _make_boundary_timed_rain_slices(
     timed_slices = [
         TimedRasterSlice(
             start_time=start_time,
-            end_time=start_time + timedelta(seconds=10) - timedelta(microseconds=1),
+            end_time=start_time + timedelta(seconds=10),
             array=np.zeros(shape, dtype=np.float32),
         ),
         TimedRasterSlice(
@@ -339,8 +339,6 @@ def test_timed_memory_rain_switches_cleanly_around_boundary(
     )
     expected_start = start_time + timedelta(seconds=expected_window[0])
     expected_end = start_time + timedelta(seconds=expected_window[1])
-    if expected_source_seconds == 0:
-        expected_end -= timedelta(microseconds=1)
     assert rain_timed_array.arr_start == expected_start
     assert rain_timed_array.arr_end == expected_end
 
@@ -372,12 +370,16 @@ def test_timed_memory_rain_is_applied_before_a_step_crosses_its_boundary(domain_
     simulation.initialize()
     simulation.update()
 
-    assert simulation.sim_time == start_time + timedelta(seconds=15)
+    assert simulation.sim_time == start_time + timedelta(seconds=10)
     domain_volume = float(
         np.sum(simulation.raster_domain.get_array("water_depth"))
         * simulation.raster_domain.cell_area
     )
-    assert domain_volume > 0.5
+    assert domain_volume == pytest.approx(0.0, abs=1e-6)
+    np.testing.assert_allclose(
+        simulation.raster_domain.get_array("rain"),
+        np.full(domain_5by5.domain_data.shape, 360.0 / (1000 * 3600), dtype=np.float32),
+    )
 
 
 def test_build_fails_when_dem_input_has_only_nan_cells(domain_5by5) -> None:

--- a/tests/core/test_hotstart_timed_inputs.py
+++ b/tests/core/test_hotstart_timed_inputs.py
@@ -261,10 +261,6 @@ def _assert_resume_with_timed_memory_inputs(
     np.testing.assert_allclose(resumed.raster_domain.get_array("rain"), checkpoint["rain"])
     np.testing.assert_allclose(resumed.raster_domain.get_array("rain"), expected_rain_arrays[10])
 
-    # TimedArray cache is rebuilt from the fresh provider during construction.
-    # After resume, the first update must realign that cache to the restored clock.
-    resumed.update()
-
     assert resumed.timed_arrays is not None
     rain_timed_array = resumed.timed_arrays["rain"]
     assert second_slice_start <= resumed.sim_time < second_slice_end
@@ -272,6 +268,10 @@ def _assert_resume_with_timed_memory_inputs(
     assert rain_timed_array.arr_end == second_slice_end
     np.testing.assert_allclose(resumed.raster_domain.get_array("rain"), expected_rain_arrays[10])
     assert not np.allclose(resumed.raster_domain.get_array("rain"), expected_rain_arrays[0])
+
+    resumed.update()
+    assert second_slice_start <= resumed.sim_time < second_slice_end
+    np.testing.assert_allclose(resumed.raster_domain.get_array("rain"), expected_rain_arrays[10])
 
     _run_to_end(resumed, skip_initialize=True)
     _assert_final_state_matches(resumed, reference)

--- a/tests/core/test_massbalance.py
+++ b/tests/core/test_massbalance.py
@@ -57,7 +57,7 @@ def test_log_absolute_time(logger_fixture):
     with open(logger_fixture["file_name"], "r") as f:
         lines = f.readlines()
         assert str(test_time) in lines[1]  # datetime formatting
-        assert "123.457" in lines[1]  # float formatting
-        assert "12.346" in lines[1]  # float formatting
+        assert "123.456789" in lines[1]  # float formatting
+        assert "12.345670" in lines[1]  # float formatting
         assert "34" in lines[1]  # int formatting
         assert "12.35%" in lines[1]  # percentage formatting

--- a/tests/core/test_memory_input.py
+++ b/tests/core/test_memory_input.py
@@ -113,7 +113,7 @@ def test_get_array_timed_returns_matching_slice_and_copy(
                         array=first_rain,
                     ),
                     TimedRasterSlice(
-                        start_time=start_time + timedelta(hours=2),
+                        start_time=start_time + timedelta(hours=1),
                         end_time=start_time + timedelta(hours=3),
                         array=second_rain,
                     ),
@@ -126,7 +126,7 @@ def test_get_array_timed_returns_matching_slice_and_copy(
         "rain", start_time + timedelta(minutes=30)
     )
     second_array, second_start, second_end = provider.get_array(
-        "rain", start_time + timedelta(hours=2, minutes=30)
+        "rain", start_time + timedelta(hours=1)
     )
 
     assert first_array is not None
@@ -135,13 +135,11 @@ def test_get_array_timed_returns_matching_slice_and_copy(
     np.testing.assert_allclose(second_array, second_rain)
     assert first_start == start_time
     assert first_end == start_time + timedelta(hours=1)
-    assert second_start == start_time + timedelta(hours=2)
+    assert second_start == start_time + timedelta(hours=1)
     assert second_end == start_time + timedelta(hours=3)
 
     second_array[0, 0] = 123.0
-    second_array_again, _, _ = provider.get_array(
-        "rain", start_time + timedelta(hours=2, minutes=30)
-    )
+    second_array_again, _, _ = provider.get_array("rain", start_time + timedelta(hours=1))
     assert second_array_again is not None
     assert second_array_again[0, 0] == pytest.approx(20.0)
 
@@ -198,7 +196,7 @@ def test_get_array_returns_none_when_time_is_not_covered(
     array, slice_start, slice_end = provider.get_array("rain", start_time + timedelta(hours=4))
 
     assert array is None
-    assert slice_start == simulation_times["start_time"]
+    assert slice_start == start_time + timedelta(hours=1)
     assert slice_end == simulation_times["end_time"]
 
 
@@ -365,7 +363,7 @@ def test_rejects_overlapping_timed_slices(
 def test_rejects_timed_slice_with_reversed_bounds(
     domain_data: DomainData, simulation_times: dict[str, datetime]
 ) -> None:
-    with pytest.raises(ValueError, match="start_time after end_time"):
+    with pytest.raises(ValueError, match="must have start_time before end_time"):
         MemoryRasterInputProvider(
             make_config(
                 domain_data,
@@ -375,6 +373,29 @@ def test_rejects_timed_slice_with_reversed_bounds(
                         TimedRasterSlice(
                             start_time=simulation_times["end_time"],
                             end_time=simulation_times["start_time"],
+                            array=np.full(domain_data.shape, 1.0, dtype=np.float32),
+                        )
+                    ]
+                },
+            )
+        )
+
+
+def test_rejects_zero_length_timed_slice(
+    domain_data: DomainData, simulation_times: dict[str, datetime]
+) -> None:
+    start_time = simulation_times["start_time"]
+
+    with pytest.raises(ValueError, match="must have start_time before end_time"):
+        MemoryRasterInputProvider(
+            make_config(
+                domain_data,
+                simulation_times,
+                timed_arrays={
+                    "rain": [
+                        TimedRasterSlice(
+                            start_time=start_time,
+                            end_time=start_time,
                             array=np.full(domain_data.shape, 1.0, dtype=np.float32),
                         )
                     ]

--- a/tests/core/test_stats.py
+++ b/tests/core/test_stats.py
@@ -29,6 +29,7 @@ def sim_5by5_stats(domain_5by5, helpers, tmp_path_factory):
         start_time=datetime(2000, 1, 1, 0, 0, 0),
         end_time=datetime(2000, 1, 1, 0, 0, 5),  # 5 seconds
         record_step=timedelta(seconds=1),
+        dtinf=1.0,
         temporal_type=TemporalType.RELATIVE,
         input_map_names=helpers.make_input_map_names(
             dem="z",
@@ -118,16 +119,20 @@ class TestStatsFile:
         expected_rain_vol = 10.0 / (1000 * 3600) * area
         # Infiltration: 2 mm/h = 2/(1000*3600) m/s (negative because it removes water)
         expected_inf_vol = -2.0 / (1000 * 3600) * area
+        expected_inf_vol_first = -2.0 / (1000 * 3600) * domain_data.cell_area
         # Losses: 1.5 mm/h = 1.5/(1000*3600) m/s (negative)
         expected_losses_vol = -1.5 / (1000 * 3600) * area
+        expected_losses_vol_first = -1.5 / (1000 * 3600) * domain_data.cell_area
         # Inflow: 0.1 m/s
         expected_inflow_vol = 0.1 * area
 
         # Ignore first row (initial state, before time-stepping)
         assert np.all(np.isclose(df["rainfall_volume"][1:], expected_rain_vol, atol=0.001))
-        assert np.all(np.isclose(df["infiltration_volume"][1:], expected_inf_vol, atol=0.001))
+        assert np.isclose(df["infiltration_volume"].iloc[1], expected_inf_vol_first, atol=0.001)
+        assert np.all(np.isclose(df["infiltration_volume"][2:], expected_inf_vol, atol=0.001))
         assert np.all(np.isclose(df["inflow_volume"][1:], expected_inflow_vol, atol=0.001))
-        assert np.all(np.isclose(df["losses_volume"][1:], expected_losses_vol, atol=0.001))
+        assert np.isclose(df["losses_volume"].iloc[1], expected_losses_vol_first, atol=0.001)
+        assert np.all(np.isclose(df["losses_volume"][2:], expected_losses_vol, atol=0.001))
 
     def test_volume_change_coherence(self, sim_5by5_stats):
         """Volume change should be coherent with other volume components."""
@@ -189,6 +194,8 @@ def _run_timed_stats_simulation(
     *,
     forcing_key: str,
     forcing_values_by_second: dict[int, float],
+    infiltration_model: InfiltrationModelType = InfiltrationModelType.NULL,
+    initial_water_depth: np.ndarray | None = None,
 ) -> pd.DataFrame:
     start_time = datetime(2000, 1, 1, 0, 0, 0)
     end_time = start_time + timedelta(seconds=20)
@@ -215,7 +222,7 @@ def _run_timed_stats_simulation(
             ["water_depth"],
         ),
         surface_flow_parameters=SurfaceFlowParameters(hmin=0.0001, dtmax=20.0, cfl=0.2),
-        infiltration_model=InfiltrationModelType.NULL,
+        infiltration_model=infiltration_model,
         stats_file=str(stats_file),
     )
     input_provider = MemoryRasterInputProvider(
@@ -226,7 +233,11 @@ def _run_timed_stats_simulation(
             "static_arrays": {
                 "dem": domain_5by5.arr_dem_flat.copy(),
                 "friction": domain_5by5.arr_n.copy(),
-                "water_depth": np.zeros(domain_5by5.domain_data.shape, dtype=np.float32),
+                "water_depth": (
+                    np.zeros(domain_5by5.domain_data.shape, dtype=np.float32)
+                    if initial_water_depth is None
+                    else initial_water_depth.copy()
+                ),
             },
             "timed_arrays": {forcing_key: forcing_slices},
         }
@@ -249,10 +260,47 @@ def _run_timed_stats_simulation(
 
 
 @pytest.mark.parametrize(
-    ("forcing_key", "forcing_values_by_second", "volume_column", "expected_volume"),
+    (
+        "forcing_key",
+        "forcing_values_by_second",
+        "volume_column",
+        "expected_volume",
+        "infiltration_model",
+        "initial_water_depth",
+    ),
     [
-        ("inflow", {0: 0.0, 3: 0.1, 20: 0.1}, "inflow_volume", 1750.0),
-        ("rain", {0: 0.0, 3: 360.0, 20: 360.0}, "rainfall_volume", 1.75),
+        (
+            "inflow",
+            {0: 0.0, 3: 0.1, 20: 0.1},
+            "inflow_volume",
+            1750.0,
+            InfiltrationModelType.NULL,
+            None,
+        ),
+        (
+            "rain",
+            {0: 0.0, 3: 360.0, 20: 360.0},
+            "rainfall_volume",
+            1.75,
+            InfiltrationModelType.NULL,
+            None,
+        ),
+        (
+            "infiltration",
+            {0: 0.0, 3: 360.0, 20: 360.0},
+            "infiltration_volume",
+            -1.75,
+            InfiltrationModelType.CONSTANT,
+            np.full((5, 5), 1.0, dtype=np.float32),
+        ),
+        (
+            "losses",
+            {0: 0.0, 3: 360.0, 20: 360.0},
+            "losses_volume",
+            -1.75,
+            InfiltrationModelType.CONSTANT,
+            np.full((5, 5), 1.0, dtype=np.float32),
+        ),
     ],
 )
 def test_timed_input_stats_first_report_row_stays_interval_coherent(
@@ -263,6 +311,8 @@ def test_timed_input_stats_first_report_row_stays_interval_coherent(
     forcing_values_by_second: dict[int, float],
     volume_column: str,
     expected_volume: float,
+    infiltration_model: InfiltrationModelType,
+    initial_water_depth: np.ndarray | None,
 ) -> None:
     df = _run_timed_stats_simulation(
         domain_5by5,
@@ -270,6 +320,8 @@ def test_timed_input_stats_first_report_row_stays_interval_coherent(
         tmp_path,
         forcing_key=forcing_key,
         forcing_values_by_second=forcing_values_by_second,
+        infiltration_model=infiltration_model,
+        initial_water_depth=initial_water_depth,
     )
 
     first_report_row = df.iloc[1]
@@ -288,7 +340,14 @@ def test_timed_input_stats_first_report_row_stays_interval_coherent(
 
 
 class TestStatsMaps:
-    """Test that output maps for mean rates have correct uniform values."""
+    """Test that mean-rate maps reflect the interval that was just simulated."""
+
+    @staticmethod
+    def _assert_center_only(arr: np.ndarray, expected_center_value: float) -> None:
+        mask = np.ones(arr.shape, dtype=bool)
+        mask[2, 2] = False
+        assert np.isclose(arr[2, 2], expected_center_value)
+        assert np.allclose(arr[mask], 0.0)
 
     def test_mean_rainfall_values(self, sim_5by5_stats):
         """Mean rainfall maps should have uniform value of 10 mm/h."""
@@ -319,7 +378,7 @@ class TestStatsMaps:
                 assert np.isclose(arr.max(), 0.1)
 
     def test_mean_infiltration_values(self, sim_5by5_stats):
-        """Mean infiltration maps should have uniform value of 2 mm/h."""
+        """Mean infiltration maps should use the hydrology rates valid for each interval."""
         simulation, _, _ = sim_5by5_stats
         output_dict = simulation.report.raster_provider.output_maps_dict
 
@@ -327,13 +386,17 @@ class TestStatsMaps:
             if i == 0:
                 # Initial map is zero
                 assert np.allclose(arr, 0)
+            elif i == 1:
+                # The first simulated interval used the t=0 hydrology rates, when only
+                # the center cell had water available for infiltration.
+                self._assert_center_only(arr, 2.0)
             else:
                 # Mean infiltration should be 2 mm/h
                 assert np.isclose(arr.min(), 2.0)
                 assert np.isclose(arr.max(), 2.0)
 
     def test_mean_losses_values(self, sim_5by5_stats):
-        """Mean losses maps should have uniform value of 1.5 mm/h."""
+        """Mean losses maps should use the hydrology rates valid for each interval."""
         simulation, _, _ = sim_5by5_stats
         output_dict = simulation.report.raster_provider.output_maps_dict
 
@@ -341,6 +404,10 @@ class TestStatsMaps:
             if i == 0:
                 # Initial map is zero
                 assert np.allclose(arr, 0)
+            elif i == 1:
+                # The first simulated interval used the t=0 hydrology rates, when only
+                # the center cell had water available for losses.
+                self._assert_center_only(arr, 1.5)
             else:
                 # Mean losses should be 1.5 mm/h
                 assert np.isclose(arr.min(), 1.5)

--- a/tests/core/test_stats.py
+++ b/tests/core/test_stats.py
@@ -8,8 +8,8 @@ import pytest
 
 from itzi.simulation_builder import SimulationBuilder
 from itzi.data_containers import SimulationConfig, SurfaceFlowParameters
+from itzi.providers.memory_input import MemoryRasterInputProvider, TimedRasterSlice
 from itzi.providers.memory_output import MemoryRasterOutputProvider, MemoryVectorOutputProvider
-from itzi.providers.xarray_input import XarrayRasterInputProvider
 from itzi.const import InfiltrationModelType, TemporalType
 
 
@@ -148,50 +148,39 @@ class TestStatsFile:
         assert np.allclose(df["vol_change_ref"], df["volume_change"], atol=1, rtol=0.01)
 
 
-def _make_timed_forcing_dataset(
+def _make_timed_forcing_slices(
     domain_5by5,
     start_time: datetime,
     *,
     forcing_key: str,
     forcing_values_by_second: dict[int, float],
-):
-    xr = pytest.importorskip("xarray")
-
-    coordinates = domain_5by5.domain_data.get_coordinates()
+) -> list[TimedRasterSlice]:
     time_slice_seconds = tuple(sorted(forcing_values_by_second))
-    time_coords = np.array(
-        [np.timedelta64(seconds, "s") for seconds in time_slice_seconds],
-        dtype="timedelta64[s]",
-    )
-    forcing_stack = np.stack(
-        [
-            np.full(
-                domain_5by5.domain_data.shape,
-                forcing_values_by_second[seconds],
-                dtype=np.float32,
-            )
-            for seconds in time_slice_seconds
-        ],
-        axis=0,
-    )
+    forcing_slices: list[TimedRasterSlice] = []
 
-    return xr.Dataset(
-        {
-            "dem": (["y", "x"], domain_5by5.arr_dem_flat.copy()),
-            "friction": (["y", "x"], domain_5by5.arr_n.copy()),
-            "water_depth": (
-                ["y", "x"],
-                np.zeros(domain_5by5.domain_data.shape, dtype=np.float32),
-            ),
-            forcing_key: (["time", "y", "x"], forcing_stack),
-        },
-        coords={
-            "time": time_coords,
-            "x": coordinates["x"],
-            "y": coordinates["y"],
-        },
-        attrs={"crs_wkt": domain_5by5.domain_data.crs_wkt},
-    )
+    for index, seconds in enumerate(time_slice_seconds[:-1]):
+        slice_start = start_time + timedelta(seconds=seconds)
+        final_boundary = start_time + timedelta(seconds=time_slice_seconds[-1])
+        if index == len(time_slice_seconds) - 2:
+            slice_end = final_boundary
+        else:
+            slice_end = start_time + timedelta(seconds=time_slice_seconds[index + 1])
+            slice_end -= timedelta(microseconds=1)
+        forcing_slices.append(
+            TimedRasterSlice(
+                start_time=slice_start,
+                end_time=slice_end,
+                array=np.full(
+                    domain_5by5.domain_data.shape,
+                    forcing_values_by_second[seconds],
+                    dtype=np.float32,
+                ),
+            )
+        )
+
+    if not forcing_slices:
+        raise ValueError(f"timed forcing '{forcing_key}' must define at least two boundaries")
+    return forcing_slices
 
 
 def _run_timed_stats_simulation(
@@ -205,7 +194,7 @@ def _run_timed_stats_simulation(
     start_time = datetime(2000, 1, 1, 0, 0, 0)
     end_time = start_time + timedelta(seconds=20)
     stats_file = tmp_path / f"timed_stats_{forcing_key}.csv"
-    dataset = _make_timed_forcing_dataset(
+    forcing_slices = _make_timed_forcing_slices(
         domain_5by5,
         start_time,
         forcing_key=forcing_key,
@@ -230,12 +219,17 @@ def _run_timed_stats_simulation(
         infiltration_model=InfiltrationModelType.NULL,
         stats_file=str(stats_file),
     )
-    input_provider = XarrayRasterInputProvider(
+    input_provider = MemoryRasterInputProvider(
         {
-            "dataset": dataset,
-            "input_map_names": sim_config.input_map_names,
+            "domain_data": domain_5by5.domain_data,
             "simulation_start_time": sim_config.start_time,
             "simulation_end_time": sim_config.end_time,
+            "static_arrays": {
+                "dem": domain_5by5.arr_dem_flat.copy(),
+                "friction": domain_5by5.arr_n.copy(),
+                "water_depth": np.zeros(domain_5by5.domain_data.shape, dtype=np.float32),
+            },
+            "timed_arrays": {forcing_key: forcing_slices},
         }
     )
     simulation = (
@@ -255,7 +249,6 @@ def _run_timed_stats_simulation(
     return pd.read_csv(stats_file)
 
 
-@pytest.mark.cloud
 @pytest.mark.parametrize(
     ("forcing_key", "forcing_values_by_second", "volume_column", "expected_volume"),
     [

--- a/tests/core/test_stats.py
+++ b/tests/core/test_stats.py
@@ -336,7 +336,7 @@ def test_timed_input_stats_first_report_row_stays_interval_coherent(
     )
 
     assert np.isclose(first_report_row[volume_column], expected_volume, atol=1e-6, rtol=1e-6)
-    assert np.isclose(first_report_row["volume_change"], volume_change_ref, atol=1e-6, rtol=1e-6)
+    assert np.isclose(first_report_row["volume_change"], volume_change_ref, atol=5e-4, rtol=1e-6)
 
 
 class TestStatsMaps:

--- a/tests/core/test_stats.py
+++ b/tests/core/test_stats.py
@@ -9,6 +9,7 @@ import pytest
 from itzi.simulation_builder import SimulationBuilder
 from itzi.data_containers import SimulationConfig, SurfaceFlowParameters
 from itzi.providers.memory_output import MemoryRasterOutputProvider, MemoryVectorOutputProvider
+from itzi.providers.xarray_input import XarrayRasterInputProvider
 from itzi.const import InfiltrationModelType, TemporalType
 
 
@@ -145,6 +146,153 @@ class TestStatsFile:
             + df["volume_error"]
         )
         assert np.allclose(df["vol_change_ref"], df["volume_change"], atol=1, rtol=0.01)
+
+
+def _make_timed_forcing_dataset(
+    domain_5by5,
+    start_time: datetime,
+    *,
+    forcing_key: str,
+    forcing_values_by_second: dict[int, float],
+):
+    xr = pytest.importorskip("xarray")
+
+    coordinates = domain_5by5.domain_data.get_coordinates()
+    time_slice_seconds = tuple(sorted(forcing_values_by_second))
+    time_coords = np.array(
+        [np.timedelta64(seconds, "s") for seconds in time_slice_seconds],
+        dtype="timedelta64[s]",
+    )
+    forcing_stack = np.stack(
+        [
+            np.full(
+                domain_5by5.domain_data.shape,
+                forcing_values_by_second[seconds],
+                dtype=np.float32,
+            )
+            for seconds in time_slice_seconds
+        ],
+        axis=0,
+    )
+
+    return xr.Dataset(
+        {
+            "dem": (["y", "x"], domain_5by5.arr_dem_flat.copy()),
+            "friction": (["y", "x"], domain_5by5.arr_n.copy()),
+            "water_depth": (
+                ["y", "x"],
+                np.zeros(domain_5by5.domain_data.shape, dtype=np.float32),
+            ),
+            forcing_key: (["time", "y", "x"], forcing_stack),
+        },
+        coords={
+            "time": time_coords,
+            "x": coordinates["x"],
+            "y": coordinates["y"],
+        },
+        attrs={"crs_wkt": domain_5by5.domain_data.crs_wkt},
+    )
+
+
+def _run_timed_stats_simulation(
+    domain_5by5,
+    helpers,
+    tmp_path,
+    *,
+    forcing_key: str,
+    forcing_values_by_second: dict[int, float],
+) -> pd.DataFrame:
+    start_time = datetime(2000, 1, 1, 0, 0, 0)
+    end_time = start_time + timedelta(seconds=20)
+    stats_file = tmp_path / f"timed_stats_{forcing_key}.csv"
+    dataset = _make_timed_forcing_dataset(
+        domain_5by5,
+        start_time,
+        forcing_key=forcing_key,
+        forcing_values_by_second=forcing_values_by_second,
+    )
+    sim_config = SimulationConfig(
+        start_time=start_time,
+        end_time=end_time,
+        record_step=timedelta(seconds=10),
+        temporal_type=TemporalType.RELATIVE,
+        input_map_names={
+            "dem": "dem",
+            "friction": "friction",
+            "water_depth": "water_depth",
+            forcing_key: forcing_key,
+        },
+        output_map_names=helpers.make_output_map_names(
+            f"out_timed_stats_{forcing_key}",
+            ["water_depth"],
+        ),
+        surface_flow_parameters=SurfaceFlowParameters(hmin=0.0001, dtmax=20.0, cfl=0.2),
+        infiltration_model=InfiltrationModelType.NULL,
+        stats_file=str(stats_file),
+    )
+    input_provider = XarrayRasterInputProvider(
+        {
+            "dataset": dataset,
+            "input_map_names": sim_config.input_map_names,
+            "simulation_start_time": sim_config.start_time,
+            "simulation_end_time": sim_config.end_time,
+        }
+    )
+    simulation = (
+        SimulationBuilder(sim_config, domain_5by5.arr_mask, np.float32)
+        .with_input_provider(input_provider)
+        .with_raster_output_provider(
+            MemoryRasterOutputProvider({"out_map_names": sim_config.output_map_names})
+        )
+        .with_vector_output_provider(MemoryVectorOutputProvider({}))
+        .build()
+    )
+
+    simulation.initialize()
+    while simulation.sim_time < simulation.end_time:
+        simulation.update()
+    simulation.finalize()
+    return pd.read_csv(stats_file)
+
+
+@pytest.mark.cloud
+@pytest.mark.parametrize(
+    ("forcing_key", "forcing_values_by_second", "volume_column", "expected_volume"),
+    [
+        ("inflow", {0: 0.0, 3: 0.1, 20: 0.1}, "inflow_volume", 1750.0),
+        ("rain", {0: 0.0, 3: 360.0, 20: 360.0}, "rainfall_volume", 1.75),
+    ],
+)
+def test_timed_input_stats_first_report_row_stays_interval_coherent(
+    domain_5by5,
+    helpers,
+    tmp_path,
+    forcing_key: str,
+    forcing_values_by_second: dict[int, float],
+    volume_column: str,
+    expected_volume: float,
+) -> None:
+    df = _run_timed_stats_simulation(
+        domain_5by5,
+        helpers,
+        tmp_path,
+        forcing_key=forcing_key,
+        forcing_values_by_second=forcing_values_by_second,
+    )
+
+    first_report_row = df.iloc[1]
+    volume_change_ref = (
+        first_report_row["boundary_volume"]
+        + first_report_row["rainfall_volume"]
+        + first_report_row["infiltration_volume"]
+        + first_report_row["inflow_volume"]
+        + first_report_row["losses_volume"]
+        + first_report_row["drainage_network_volume"]
+        + first_report_row["volume_error"]
+    )
+
+    assert np.isclose(first_report_row[volume_column], expected_volume, atol=1e-6, rtol=1e-6)
+    assert np.isclose(first_report_row["volume_change"], volume_change_ref, atol=1e-6, rtol=1e-6)
 
 
 class TestStatsMaps:

--- a/tests/core/test_stats.py
+++ b/tests/core/test_stats.py
@@ -165,7 +165,6 @@ def _make_timed_forcing_slices(
             slice_end = final_boundary
         else:
             slice_end = start_time + timedelta(seconds=time_slice_seconds[index + 1])
-            slice_end -= timedelta(microseconds=1)
         forcing_slices.append(
             TimedRasterSlice(
                 start_time=slice_start,

--- a/tests/core/test_wse.py
+++ b/tests/core/test_wse.py
@@ -153,7 +153,7 @@ def test_timed_memory_input_updates_water_depth_from_wse(domain_5by5) -> None:
                 "water_surface_elevation": [
                     TimedRasterSlice(
                         start_time=start_time,
-                        end_time=boundary_time - timedelta(microseconds=1),
+                        end_time=boundary_time,
                         array=first_wse,
                     ),
                     TimedRasterSlice(
@@ -185,7 +185,7 @@ def test_timed_memory_input_updates_water_depth_from_wse(domain_5by5) -> None:
     assert simulation.timed_arrays is not None
     wse_timed_array = simulation.timed_arrays["water_surface_elevation"]
     assert wse_timed_array.arr_start == start_time
-    assert wse_timed_array.arr_end == boundary_time - timedelta(microseconds=1)
+    assert wse_timed_array.arr_end == boundary_time
 
     simulation.update_until(timedelta(seconds=10))
 

--- a/tests/core/test_xarray_input.py
+++ b/tests/core/test_xarray_input.py
@@ -300,9 +300,59 @@ def test_xarray_input_provider_get_array_time_dependent_variable(
         # Verify times
         assert isinstance(start_time, datetime)
         assert isinstance(end_time, datetime)
-        assert start_time <= current_time <= end_time
+        assert start_time <= current_time < end_time
         assert start_time == expected_start_time
         assert end_time == expected_end_time
+
+
+def test_xarray_input_provider_uses_half_open_windows_at_exact_boundary(
+    xarray_input_data: Dict, default_times: Dict
+):
+    config: XarrayRasterInputConfig = {
+        "dataset": xarray_input_data["dataset"],
+        "input_map_names": xarray_input_data["input_map_names"],
+        "simulation_start_time": default_times["start_time"],
+        "simulation_end_time": default_times["end_time"],
+    }
+
+    provider = XarrayRasterInputProvider(config)
+
+    current_time = datetime(2023, 1, 1, 2, 0, 0)
+    array, start_time, end_time = provider.get_array("rainfall", current_time)
+
+    expected_time_index = 2
+    base_data = xarray_input_data["input_maps_dict"]["rainfall"]
+    expected_array = base_data * (1 + 0.1 * expected_time_index)
+
+    assert np.allclose(array, expected_array)
+    assert start_time == datetime(2023, 1, 1, 2, 0, 0)
+    assert end_time == datetime(2023, 1, 1, 3, 0, 0)
+    assert start_time <= current_time < end_time
+
+
+def test_xarray_input_provider_extends_last_slice_to_simulation_end(
+    xarray_input_data: Dict, default_times: Dict
+):
+    config: XarrayRasterInputConfig = {
+        "dataset": xarray_input_data["dataset"],
+        "input_map_names": xarray_input_data["input_map_names"],
+        "simulation_start_time": default_times["start_time"],
+        "simulation_end_time": default_times["end_time"],
+    }
+
+    provider = XarrayRasterInputProvider(config)
+
+    current_time = datetime(2023, 1, 1, 4, 30, 0)
+    array, start_time, end_time = provider.get_array("rainfall", current_time)
+
+    expected_time_index = 4
+    base_data = xarray_input_data["input_maps_dict"]["rainfall"]
+    expected_array = base_data * (1 + 0.1 * expected_time_index)
+
+    assert np.allclose(array, expected_array)
+    assert start_time == datetime(2023, 1, 1, 4, 0, 0)
+    assert end_time == default_times["end_time"]
+    assert start_time <= current_time < end_time
 
 
 def test_xarray_input_provider_get_array_nonexistent_key(
@@ -495,7 +545,7 @@ def test_xarray_input_provider_get_array_time_dependent_variable_relative_time(
         # Verify times
         assert isinstance(start_time, datetime)
         assert isinstance(end_time, datetime)
-        assert start_time <= current_time <= end_time
+        assert start_time <= current_time < end_time
         assert start_time == expected_start_time
         assert end_time == expected_end_time
 
@@ -947,7 +997,7 @@ def test_xarray_input_provider_mixed_dimensions(mixed_dimensions_data: Dict, def
     # Verify times
     assert isinstance(start_time, datetime)
     assert isinstance(end_time, datetime)
-    assert start_time <= current_time <= end_time
+    assert start_time <= current_time < end_time
     assert start_time == expected_start_time
     assert end_time == expected_end_time
 
@@ -978,7 +1028,7 @@ def test_xarray_input_provider_mixed_dimensions(mixed_dimensions_data: Dict, def
     # Verify times
     assert isinstance(start_time, datetime)
     assert isinstance(end_time, datetime)
-    assert start_time <= current_time <= end_time
+    assert start_time <= current_time < end_time
     assert start_time == expected_start_time
     assert end_time == expected_end_time
 

--- a/tests/grass/test_itzi.py
+++ b/tests/grass/test_itzi.py
@@ -258,12 +258,16 @@ def test_timed_grass_rain_is_applied_before_a_step_crosses_its_boundary(test_dat
         simulation = sim_runner.sim
         simulation.update()
 
-        assert simulation.sim_time == simulation.start_time + timedelta(seconds=15)
+        assert simulation.sim_time == simulation.start_time + timedelta(seconds=10)
         domain_volume = float(
             np.sum(simulation.raster_domain.get_array("water_depth"))
             * simulation.raster_domain.cell_area
         )
-        assert domain_volume > 0.5
+        assert domain_volume == pytest.approx(0.0, abs=1e-6)
+        np.testing.assert_allclose(
+            simulation.raster_domain.get_array("rain"),
+            360.0 / (1000 * 3600),
+        )
     finally:
         sim_runner.g_interface.finalize()
         sim_runner.g_interface.cleanup()

--- a/tests/grass/test_itzi.py
+++ b/tests/grass/test_itzi.py
@@ -1,14 +1,98 @@
 """ """
 
 from configparser import ConfigParser
+from datetime import timedelta
 import os
+from uuid import uuid4
 
 import grass.script as gscript
+import numpy as np
 import pytest
 
 from itzi import SimulationRunner
 from itzi.configreader import ConfigReader
 from itzi.itzi_error import ItziFatal
+
+
+def _create_timed_rain_inputs(name_prefix: str) -> dict[str, str]:
+    current_mapset = gscript.read_command("g.mapset", flags="p").rstrip()
+    suffix = uuid4().hex[:8]
+    zero_depth_map = f"{name_prefix}_start_h_zero_{suffix}"
+    rain_map_names = [
+        f"{name_prefix}_rain_0_{suffix}",
+        f"{name_prefix}_rain_10_{suffix}",
+        f"{name_prefix}_rain_20_{suffix}",
+    ]
+    strds_name = f"{name_prefix}_rain_{suffix}"
+
+    gscript.mapcalc(f"{zero_depth_map}=0")
+    gscript.mapcalc(f"{rain_map_names[0]}=0")
+    gscript.mapcalc(f"{rain_map_names[1]}=360")
+    gscript.mapcalc(f"{rain_map_names[2]}=360")
+    gscript.run_command(
+        "t.create",
+        output=strds_name,
+        type="strds",
+        temporaltype="relative",
+        semantictype="mean",
+        title=strds_name,
+        description=strds_name,
+    )
+    gscript.run_command(
+        "t.register",
+        flags="i",
+        input=strds_name,
+        type="raster",
+        maps=",".join(rain_map_names),
+        start="0",
+        increment="10",
+        unit="seconds",
+    )
+
+    return {
+        "rain": f"{strds_name}@{current_mapset}",
+        "water_depth": f"{zero_depth_map}@{current_mapset}",
+    }
+
+
+def _build_timed_rain_runner(
+    test_data_temp_path: str,
+    *,
+    input_names: dict[str, str],
+    duration: str,
+    record_step: str,
+    prefix: str,
+) -> SimulationRunner:
+    current_mapset = gscript.read_command("g.mapset", flags="p").rstrip()
+    config_dict = {
+        "input": {
+            "dem": f"z@{current_mapset}",
+            "friction": f"n@{current_mapset}",
+            "water_depth": input_names["water_depth"],
+            "rain": input_names["rain"],
+        },
+        "time": {
+            "duration": duration,
+            "record_step": record_step,
+        },
+        "output": {
+            "prefix": prefix,
+            "values": "water_depth",
+        },
+        "options": {
+            "hmin": "0.0001",
+            "dtmax": "20",
+            "cfl": "0.2",
+        },
+    }
+    parser = ConfigParser()
+    parser.read_dict(config_dict)
+    config_file = os.path.join(test_data_temp_path, f"{prefix}.ini")
+    with open(config_file, "w") as file_handle:
+        parser.write(file_handle)
+
+    conf_data = ConfigReader(config_file)
+    return SimulationRunner(conf_data.get_sim_params(), conf_data.get_grass_params())
 
 
 @pytest.mark.forked
@@ -110,3 +194,76 @@ def test_fails_when_region_has_no_dem_data(test_data_temp_path):
 
     with pytest.raises(ItziFatal, match=r"input map <dem> contains only NULL/NaN cells"):
         SimulationRunner(conf_data.get_sim_params(), conf_data.get_grass_params())
+
+
+@pytest.mark.forked
+@pytest.mark.usefixtures("grass_5by5")
+@pytest.mark.parametrize(
+    ("target_seconds", "expected_rain_mm_per_hour", "expected_window_seconds"),
+    [
+        (9, 0.0, (0, 10)),
+        (10, 360.0, (10, 20)),
+        (12, 360.0, (10, 20)),
+    ],
+)
+def test_timed_grass_rain_switches_cleanly_around_boundary(
+    test_data_temp_path,
+    target_seconds: int,
+    expected_rain_mm_per_hour: float,
+    expected_window_seconds: tuple[int, int],
+):
+    input_names = _create_timed_rain_inputs("timed_boundary")
+    sim_runner = _build_timed_rain_runner(
+        test_data_temp_path,
+        input_names=input_names,
+        duration="00:00:20",
+        record_step="00:00:20",
+        prefix=f"out_timed_boundary_{target_seconds}_{uuid4().hex[:8]}",
+    )
+
+    try:
+        simulation = sim_runner.sim
+        simulation.update_until(timedelta(seconds=target_seconds))
+
+        assert simulation.timed_arrays is not None
+        rain_timed_array = simulation.timed_arrays["rain"]
+        np.testing.assert_allclose(
+            simulation.raster_domain.get_array("rain"),
+            expected_rain_mm_per_hour / (1000 * 3600),
+        )
+        assert rain_timed_array.arr_start == simulation.start_time + timedelta(
+            seconds=expected_window_seconds[0]
+        )
+        assert rain_timed_array.arr_end == simulation.start_time + timedelta(
+            seconds=expected_window_seconds[1]
+        )
+    finally:
+        sim_runner.g_interface.finalize()
+        sim_runner.g_interface.cleanup()
+
+
+@pytest.mark.forked
+@pytest.mark.usefixtures("grass_5by5")
+def test_timed_grass_rain_is_applied_before_a_step_crosses_its_boundary(test_data_temp_path):
+    input_names = _create_timed_rain_inputs("timed_crossing")
+    sim_runner = _build_timed_rain_runner(
+        test_data_temp_path,
+        input_names=input_names,
+        duration="00:00:20",
+        record_step="00:00:15",
+        prefix=f"out_timed_crossing_{uuid4().hex[:8]}",
+    )
+
+    try:
+        simulation = sim_runner.sim
+        simulation.update()
+
+        assert simulation.sim_time == simulation.start_time + timedelta(seconds=15)
+        domain_volume = float(
+            np.sum(simulation.raster_domain.get_array("water_depth"))
+            * simulation.raster_domain.cell_area
+        )
+        assert domain_volume > 0.5
+    finally:
+        sim_runner.g_interface.finalize()
+        sim_runner.g_interface.cleanup()


### PR DESCRIPTION
- [x] Adopt a half-open time interval for input maps validity, excluding the end time
- [x] Force time-stepping at input maps update
- [x] Add or update relevant tests
- [x] Refactor Simulation:update() for clearer model and record orchestration
- [x] Resolves #198 