### PR TITLE
Check temporal type of STDS at init

### DIFF
--- a/src/itzi/providers/grass_interface.py
+++ b/src/itzi/providers/grass_interface.py
@@ -438,6 +438,30 @@ class GrassInterface:
             ]
         return [self.MapData(*i) for i in maplist]
 
+    def validate_output_stds_temporal_type(
+        self,
+        stds_name: str | None,
+        stds_type: str,
+        expected_temporal_type: TemporalType,
+    ) -> None:
+        """Fail early when overwriting an STDS with incompatible temporal type."""
+        if not stds_name or not self.overwrite:
+            return
+
+        stds_id = self.format_id(stds_name)
+        stds = tgis.dataset_factory(stds_type, stds_id)
+        if stds is None or not stds.is_in_db():
+            return
+
+        existing_stds = tgis.open_stds.open_old_stds(stds_id, stds_type)
+        existing_temporal_type = TemporalType(existing_stds.get_temporal_type())
+        if existing_temporal_type != expected_temporal_type:
+            msgr.fatal(
+                f"Output {stds_type.upper()} <{stds_name}> already exists with "
+                f"{existing_temporal_type} temporal type and cannot be overwritten "
+                f"by a {expected_temporal_type} simulation"
+            )
+
     def read_raster_map(self, rast_name: str) -> np.ndarray:
         """Read a GRASS raster and return a numpy array"""
         if self.non_blocking_write:

--- a/src/itzi/providers/grass_output.py
+++ b/src/itzi/providers/grass_output.py
@@ -18,6 +18,7 @@ from typing import Dict, TypedDict, Union, TYPE_CHECKING
 
 import numpy as np
 
+from itzi.const import TemporalType
 from itzi.providers.base import RasterOutputProvider, VectorOutputProvider
 
 if TYPE_CHECKING:
@@ -30,13 +31,13 @@ class GrassRasterOutputConfig(TypedDict):
     grass_interface: "GrassInterface"
     out_map_names: Dict[str, str]
     hmin: float
-    temporal_type: str
+    temporal_type: TemporalType
 
 
 class GrassVectorOutputConfig(TypedDict):
     grass_interface: "GrassInterface"
     drainage_map_name: str
-    temporal_type: str
+    temporal_type: TemporalType
 
 
 class GrassRasterOutputProvider(RasterOutputProvider):
@@ -49,6 +50,12 @@ class GrassRasterOutputProvider(RasterOutputProvider):
         self.out_map_names = config["out_map_names"]
         self.hmin = config["hmin"]
         self.temporal_type = config["temporal_type"]
+        for stds_name in self.out_map_names.values():
+            self.grass_interface.validate_output_stds_temporal_type(
+                stds_name=stds_name,
+                stds_type="strds",
+                expected_temporal_type=self.temporal_type,
+            )
         self.record_counter = {k: 0 for k in self.out_map_names.keys()}
         self.output_maplist = {k: [] for k in self.out_map_names.keys()}
 
@@ -106,6 +113,11 @@ class GrassVectorOutputProvider(VectorOutputProvider):
         self.grass_interface = config["grass_interface"]
         self.drainage_map_name = config["drainage_map_name"]
         self.temporal_type = config["temporal_type"]
+        self.grass_interface.validate_output_stds_temporal_type(
+            stds_name=self.drainage_map_name,
+            stds_type="stvds",
+            expected_temporal_type=self.temporal_type,
+        )
 
         self.record_counter = 0
         self.vector_drainage_maplist = []

--- a/tests/grass/test_temporal_overwrite.py
+++ b/tests/grass/test_temporal_overwrite.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from configparser import ConfigParser
+import os
+from uuid import uuid4
+
+import grass.script as gscript
+import pytest
+
+from itzi import SimulationRunner
+from itzi.configreader import ConfigReader
+from itzi.const import TemporalType
+
+
+def _build_runner(
+    test_data_temp_path: str,
+    prefix: str,
+    temporal_type: TemporalType,
+) -> SimulationRunner:
+    current_mapset = gscript.read_command("g.mapset", flags="p").rstrip()
+    config_dict = {
+        "input": {
+            "dem": f"z@{current_mapset}",
+            "friction": f"n@{current_mapset}",
+            "water_depth": f"start_h@{current_mapset}",
+        },
+        "time": {
+            "record_step": "00:00:10",
+        },
+        "output": {
+            "prefix": prefix,
+            "values": "water_depth",
+        },
+        "options": {
+            "hmin": "0.0001",
+            "dtmax": "0.3",
+            "cfl": "0.2",
+        },
+    }
+    if temporal_type == TemporalType.RELATIVE:
+        config_dict["time"]["duration"] = "00:00:10"
+    else:
+        config_dict["time"].update(
+            {
+                "start_time": "2020-01-01 00:00",
+                "duration": "00:00:10",
+            }
+        )
+
+    parser = ConfigParser()
+    parser.read_dict(config_dict)
+    config_file = os.path.join(test_data_temp_path, f"{prefix}.ini")
+    with open(config_file, "w") as file_handle:
+        parser.write(file_handle)
+
+    conf_data = ConfigReader(config_file)
+    return SimulationRunner(conf_data.get_sim_params(), conf_data.get_grass_params())
+
+
+@pytest.mark.forked
+@pytest.mark.usefixtures("grass_5by5")
+@pytest.mark.parametrize(
+    ("existing_temporal_type", "simulation_temporal_type"),
+    [
+        (TemporalType.RELATIVE, TemporalType.ABSOLUTE),
+        (TemporalType.ABSOLUTE, TemporalType.RELATIVE),
+    ],
+)
+def test_finalize_fails_when_overwriting_strds_with_different_temporal_type(
+    monkeypatch: pytest.MonkeyPatch,
+    test_data_temp_path: str,
+    existing_temporal_type: TemporalType,
+    simulation_temporal_type: TemporalType,
+) -> None:
+    monkeypatch.setenv("GRASS_OVERWRITE", "1")
+
+    prefix = f"out_overwrite_{existing_temporal_type}_{simulation_temporal_type}_{uuid4().hex[:8]}"
+    initial_runner = _build_runner(test_data_temp_path, prefix, existing_temporal_type)
+    initial_runner.run().finalize()
+
+    sim_runner = _build_runner(test_data_temp_path, prefix, simulation_temporal_type)
+
+    try:
+        sim_runner.run()
+
+        with pytest.raises(Exception):
+            sim_runner.finalize()
+    finally:
+        sim_runner.g_interface.finalize()
+        sim_runner.g_interface.cleanup()

--- a/tests/grass/test_temporal_overwrite.py
+++ b/tests/grass/test_temporal_overwrite.py
@@ -10,6 +10,7 @@ import pytest
 from itzi import SimulationRunner
 from itzi.configreader import ConfigReader
 from itzi.const import TemporalType
+from itzi.itzi_error import ItziFatal
 
 
 def _build_runner(
@@ -66,7 +67,7 @@ def _build_runner(
         (TemporalType.ABSOLUTE, TemporalType.RELATIVE),
     ],
 )
-def test_finalize_fails_when_overwriting_strds_with_different_temporal_type(
+def test_runner_creation_fails_when_overwriting_strds_with_different_temporal_type(
     monkeypatch: pytest.MonkeyPatch,
     test_data_temp_path: str,
     existing_temporal_type: TemporalType,
@@ -78,13 +79,5 @@ def test_finalize_fails_when_overwriting_strds_with_different_temporal_type(
     initial_runner = _build_runner(test_data_temp_path, prefix, existing_temporal_type)
     initial_runner.run().finalize()
 
-    sim_runner = _build_runner(test_data_temp_path, prefix, simulation_temporal_type)
-
-    try:
-        sim_runner.run()
-
-        with pytest.raises(Exception):
-            sim_runner.finalize()
-    finally:
-        sim_runner.g_interface.finalize()
-        sim_runner.g_interface.cleanup()
+    with pytest.raises(ItziFatal, match=r"temporal type"):
+        _build_runner(test_data_temp_path, prefix, simulation_temporal_type)


### PR DESCRIPTION
- [x] Add a STDS temporal check at GRASS output providers __init__
- [x] Add a related parametrized test
- [x] Resolves #49 